### PR TITLE
Bump idna 3.13 → 3.16 (CVE-2026-45409)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -715,11 +715,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps transitive dep `idna` from 3.13 → 3.16 in `uv.lock` (via anyio / httpx / requests).
- Resolves Dependabot alert #1: [CVE-2026-45409](https://nvd.nist.gov/vuln/detail/CVE-2026-45409) / [GHSA-65pc-fj4g-8rjx](https://github.com/kjd/idna/security/advisories/GHSA-65pc-fj4g-8rjx) — medium-severity DoS in `idna.encode()` on crafted long inputs. Fix landed in 3.15.
- No `pyproject.toml` change needed; idna isn't a direct dep.

## Test plan
- [x] `uv sync` clean, `import idna` reports 3.16
- [x] `idna.encode('example.com')` works
- [x] HTTP smoke tests (`tests/test_http.py`) all pass locally
- [ ] CI: smoke (3.11), smoke (3.13), docker green