### PR TITLE
metrics: persistent recent-errors ring buffer at /metrics

### DIFF
--- a/server.py
+++ b/server.py
@@ -2514,6 +2514,12 @@ _STATS: dict[str, Any] = {
     "by_path": {},
 }
 
+# Ring buffer of recent 5xx errors so they're inspectable at /metrics
+# without depending on Fly's short-lived log tail. PII-free: only
+# timestamp, path, status, and (when known) the exception type — never
+# request bodies. Persisted with the counters so they survive restarts.
+_recent_errors: collections.deque = collections.deque(maxlen=20)
+
 # Persistence: if ESTNLTK_MCP_METRICS_PATH is set (default
 # /data/metrics.json — matches the Fly volume mount), counters survive
 # machine restarts. Locally, the path's parent dir doesn't exist and
@@ -2537,6 +2543,9 @@ def _load_persistent_stats() -> None:
         _STATS["by_path"] = {str(k): int(v) for k, v in (data.get("by_path") or {}).items()}
         _TOOL_CALLS.clear()
         _TOOL_CALLS.update({str(k): int(v) for k, v in (data.get("tool_calls") or {}).items()})
+        _recent_errors.clear()
+        for e in (data.get("recent_errors") or []):
+            _recent_errors.append(e)
         log.info(
             "metrics persistence: restored total=%d, tool_calls=%d from %s",
             _STATS["total"], sum(_TOOL_CALLS.values()), _METRICS_PATH,
@@ -2558,11 +2567,22 @@ def _save_persistent_stats() -> None:
             "by_status": _STATS["by_status"],
             "by_path": _STATS["by_path"],
             "tool_calls": _TOOL_CALLS,
+            "recent_errors": list(_recent_errors),
             "saved_at_unix": int(time.time()),
         }))
         tmp.replace(_METRICS_PATH)
     except Exception as e:
         log.warning("metrics persistence: failed to save %s: %s", _METRICS_PATH, e)
+
+
+def _record_error(path: str, status: int, error: str | None) -> None:
+    """Append a PII-free breadcrumb for a 5xx response to the ring buffer."""
+    _recent_errors.append({
+        "ts": int(time.time()),
+        "path": path,
+        "status": status,
+        "error": error,
+    })
 
 
 def _stats_record(status: int, path: str) -> None:
@@ -2716,11 +2736,17 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
         path = scope.get("path", "")
         # Wrap send so we can capture the final response status for
         # /metrics without changing the inner app's contract.
-        captured = {"status": 0}
+        captured: dict[str, Any] = {"status": 0, "error": None}
 
         async def send(message):
             if message["type"] == "http.response.start":
-                captured["status"] = message.get("status", 0)
+                status = message.get("status", 0)
+                captured["status"] = status
+                # Record any 5xx — covers both exceptions our wrapper
+                # catches (error type set below) AND 500s the inner MCP
+                # app returns on its own (error stays None).
+                if status >= 500:
+                    _record_error(path, status, captured.get("error"))
             await send_raw(message)
 
         try:
@@ -2771,6 +2797,7 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                     "by_path": dict(_STATS["by_path"]),
                     "tool_calls_total": sum(_TOOL_CALLS.values()),
                     "tool_calls": dict(_TOOL_CALLS),
+                    "recent_errors": list(_recent_errors),
                     "uptime_seconds": int(time.time() - _STATS_START_TS),
                     "started_at_unix": int(_STATS_START_TS),
                     "note": (
@@ -2784,8 +2811,12 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                         "so with >1 machine each tracks its own and /metrics "
                         "reflects whichever served the request. started_at_unix "
                         "is the process start, NOT when tracking began — the "
-                        "counts span all persisted history. Records tool NAME "
-                        "+ count only, never arguments; privacy posture in "
+                        "counts span all persisted history. recent_errors is a "
+                        "ring buffer of the last 20 5xx responses (ts, path, "
+                        "status, exception type) so failures are inspectable "
+                        "here without Fly's short-lived log tail; it persists "
+                        "with the counters. Records tool NAME + count only, "
+                        "never arguments; PII-free; privacy posture in "
                         "SECURITY.md is unchanged."
                     ),
                 }
@@ -2890,12 +2921,17 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
             # BaseException, so it passes through here and normal stream
             # teardown proceeds untouched.
             log.error("unhandled error on %s: %s", path, type(exc).__name__)
+            # Stash the exception type so the send wrapper records it on the
+            # ring buffer when the 500 below goes out.
+            captured["error"] = type(exc).__name__
             if captured["status"] == 0:
                 await _send_status(send, 500, {"error": "internal_error"})
             else:
-                # Response already in flight (e.g. mid-SSE-stream); we
-                # can't cleanly send a 500, so let the server framework
-                # close the half-sent connection.
+                # Response already in flight (e.g. mid-SSE-stream); we can't
+                # cleanly send a 500, so let the server framework close the
+                # half-sent connection. No new http.response.start will fire,
+                # so record the breadcrumb directly here.
+                _record_error(path, captured["status"], type(exc).__name__)
                 raise
         finally:
             _stats_record(captured["status"] or 0, path)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -113,6 +113,7 @@ async def run() -> None:
         check("metrics has by_status dict", isinstance(body.get("by_status"), dict))
         check("metrics has by_path dict", isinstance(body.get("by_path"), dict))
         check("metrics has uptime_seconds", "uptime_seconds" in body)
+        check("metrics has recent_errors list", isinstance(body.get("recent_errors"), list))
 
         print("auth")
         r = await c.post("/mcp", json={})
@@ -191,12 +192,25 @@ async def run() -> None:
         check("public: per-IP rate limit triggers 429", 429 in statuses, str(statuses))
 
     print("unhandled-error guard")
+    server._recent_errors.clear()
     boom_app = server._build_http_app(token=None, rate_limit=50, public_mode=True, inner=boom_inner)
     transport2 = httpx.ASGITransport(app=boom_app)
     async with httpx.AsyncClient(transport=transport2, base_url="http://t") as c:
         r = await c.post("/mcp", json={})
         check("inner exception → clean 500 (not a raw crash)", r.status_code == 500, str(r.status_code))
         check("500 body is structured", r.json().get("error") == "internal_error", str(r.json()))
+
+        # The 500 should leave a PII-free breadcrumb in the ring buffer,
+        # visible at /metrics, with the exception type captured.
+        r = await c.get("/metrics")
+        errs = r.json().get("recent_errors", [])
+        check("recent_errors captured the 500", len(errs) >= 1, str(errs))
+        if errs:
+            last = errs[-1]
+            check("recent_error path is /mcp", last.get("path") == "/mcp", str(last))
+            check("recent_error status is 500", last.get("status") == 500, str(last))
+            check("recent_error type is RuntimeError", last.get("error") == "RuntimeError", str(last))
+            check("recent_error has ts", isinstance(last.get("ts"), int), str(last))
 
 
 def metrics_persistence_test() -> None:
@@ -209,22 +223,28 @@ def metrics_persistence_test() -> None:
     saved_total = server._STATS["total"]
     saved_status = dict(server._STATS["by_status"])
     saved_pathd = dict(server._STATS["by_path"])
+    saved_errors = list(server._recent_errors)
     try:
         with tempfile.TemporaryDirectory() as d:
             server._METRICS_PATH = Path(d) / "metrics.json"
             server._STATS["total"] = 12345
             server._STATS["by_status"] = {"200": 12000, "429": 345}
             server._STATS["by_path"] = {"/mcp": 12300, "/health": 45}
+            server._recent_errors.clear()
+            server._recent_errors.append({"ts": 1700000000, "path": "/mcp", "status": 500, "error": "RuntimeError"})
             server._save_persistent_stats()
             check("file written", server._METRICS_PATH.exists())
             # wipe + restore
             server._STATS["total"] = 0
             server._STATS["by_status"] = {}
             server._STATS["by_path"] = {}
+            server._recent_errors.clear()
             server._load_persistent_stats()
             check("total restored", server._STATS["total"] == 12345)
             check("by_status restored", server._STATS["by_status"] == {"200": 12000, "429": 345})
             check("by_path restored", server._STATS["by_path"] == {"/mcp": 12300, "/health": 45})
+            check("recent_errors restored", list(server._recent_errors) == [
+                {"ts": 1700000000, "path": "/mcp", "status": 500, "error": "RuntimeError"}], str(list(server._recent_errors)))
             # graceful no-op when parent dir is gone (local dev path)
             server._METRICS_PATH = Path("/this/path/does/not/exist/metrics.json")
             try:
@@ -237,6 +257,8 @@ def metrics_persistence_test() -> None:
         server._STATS["total"] = saved_total
         server._STATS["by_status"] = saved_status
         server._STATS["by_path"] = saved_pathd
+        server._recent_errors.clear()
+        server._recent_errors.extend(saved_errors)
 
 
 asyncio.run(run())


### PR DESCRIPTION
## Why

`fly logs -a estonian-mcp | grep 'unhandled error'` returns nothing useful: it's a *live tail* with short retention, so past 500s are already gone, and not every 5xx leaves the log breadcrumb. There was no way to inspect recent failures after the fact without a third-party log drain.

## What

Adds a small persistent ring buffer of the last 20 5xx responses, exposed at `/metrics` and persisted to the Fly volume alongside the existing counters — so failures survive restarts and are inspectable with a plain `curl /metrics`, no Sentry/log-drain.

Each entry is PII-free: `{ts, path, status, error}` where `error` is the exception type name (or `null` for a 500 the inner MCP app returned on its own). Never request bodies, never tokens.

- The `send` wrapper records any 5xx as the response status is observed — covering both inner-app 500s and exceptions the wrapper catches.
- The `except` block stashes the exception type so it's attached to the breadcrumb; the mid-stream re-raise path records directly.
- Buffer is saved/restored in `_save_persistent_stats` / `_load_persistent_stats` and surfaced in the `/metrics` payload + note.

## Tests

`tests/test_http.py` extended: asserts `/metrics` exposes `recent_errors`, that a simulated inner failure lands a breadcrumb (`path=/mcp`, `status=500`, `error=RuntimeError`, integer `ts`), and that the buffer round-trips through persistence. Full HTTP suite passes locally; smoke suite passes except the two fastText tools that need the model absent locally (covered in CI's docker job).

## Activate

After merge: `fly deploy`, then `curl https://estonian-mcp.fly.dev/metrics` to see `recent_errors`.