### PR TITLE
docs: attribute inflection_et to TalTech, not EKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ in ground truth so it stops guessing on the mechanical layer
 (spelling, case forms, conjugation) and gives it real Estonian
 synonyms instead of inventing them.
 
-> **Benchmark:** on EKI's [`inflection_et`](https://huggingface.co/datasets/TalTechNLP/inflection_et)
-> gold dataset (the noun-phrase inflection task behind
-> [Keelemudelite mõõdupuu](https://moodupuu.eki.ee/)), our morphology
+> **Benchmark:** on TalTech's [`inflection_et`](https://huggingface.co/datasets/TalTechNLP/inflection_et)
+> gold dataset (a noun-phrase inflection benchmark; Lillepalu & Alumäe,
+> [arXiv:2510.21193](https://arxiv.org/abs/2510.21193v2)), our morphology
 > engine scores **96.5% first-candidate / 99.1% any-candidate** over
 > 1,400 items. Reproduce: `uv run python scripts/eval_inflection.py`.
 > (We're a tool server, not a rankable LLM — this scores our tools
-> against the same gold data the leaderboard uses.)
+> against published gold data.)
 
 **Three ways to use it:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,8 +68,8 @@ Then bump the MD5 in `Dockerfile` and `.github/workflows/ci.yml`.
 Benchmarks estonian-mcp's morphology engine (Vabamorf, the synthesizer
 behind the `paradigm` tool) against TalTechNLP's
 [`inflection_et`](https://huggingface.co/datasets/TalTechNLP/inflection_et)
-dataset — the noun-phrase inflection task from EKI's
-[Keelemudelite mõõdupuu](https://moodupuu.eki.ee/).
+dataset — a noun-phrase inflection benchmark (Lillepalu & Alumäe,
+[arXiv:2510.21193](https://arxiv.org/abs/2510.21193v2)).
 
 estonian-mcp is a tool server, not an LLM, so it can't be ranked on the
 model leaderboard. This instead scores our synthesis directly against

--- a/scripts/eval_inflection.py
+++ b/scripts/eval_inflection.py
@@ -1,6 +1,6 @@
 """Benchmark estonian-mcp's morphology engine against TalTechNLP's
-`inflection_et` dataset — the noun-phrase inflection task from EKI's
-Keelemudelite mõõdupuu (https://moodupuu.eki.ee/).
+`inflection_et` dataset — a noun-phrase inflection benchmark
+(Lillepalu & Alumäe, https://arxiv.org/abs/2510.21193v2).
 
 estonian-mcp is a tool server, not a language model, so it can't be
 "ranked on the leaderboard". Instead this scores our morphological

--- a/server.py
+++ b/server.py
@@ -727,7 +727,7 @@ def _is_indeclinable_attr(word: str) -> bool:
     """True if a word does NOT inflect when used attributively (before a
     noun), so adjective-noun agreement should leave it in base form.
 
-    Two cases, both verified against EKI's inflection_et benchmark:
+    Two cases, both verified against TalTech's inflection_et benchmark:
     - lexical indeclinables (täis, eri, väärt, ...)
     - past participles in -tud / -dud / -nud, which are invariant in
       attributive position (`tuntud laulja` → `tuntud laulja` in the


### PR DESCRIPTION
## Why

`inflection_et` is **TalTechNLP's** noun-phrase inflection benchmark (Helena Grete Lillepalu & Tanel Alumäe, [arXiv:2510.21193](https://arxiv.org/abs/2510.21193v2)) — *not* an EKI dataset. The repo described it as "EKI's `inflection_et`" / "the task from EKI's Keelemudelite mõõdupuu", conflating TalTech's dataset with EKI's leaderboard (the HuggingFace path `TalTechNLP/inflection_et` already gave the game away).

## What

Corrected the attribution in:
- the README **Benchmark** callout (the public "snippet"),
- the `_is_indeclinable_attr` docstring in `server.py`,
- both eval scripts (`scripts/eval_inflection.py`, `scripts/README.md`).

`EKI Reeglid` references elsewhere are left as-is — those are correct (EKI's orthography rules, which the orthography tools encode). The GitHub repo **About** description was updated separately (live) to read "Scores 96.5% on TalTech's inflection_et benchmark."

Docs/comments only — no behaviour change, no redeploy needed.