### PR TITLE
metrics: add sessions_total (privacy-safe connection proxy)

### DIFF
--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -69,8 +69,12 @@ jobs:
               str(m.get("tool_calls_total", "")),
               str(m.get("by_path", {}).get("/mcp", "")),
               str(m.get("total_requests", "")),
+              str(m.get("sessions_total", "")),
           ])
-          header = "date,tool_calls_total,mcp_requests,total_requests"
+          # sessions_total appended as a trailing column; rows logged before
+          # the counter existed simply omit it (4 fields), which DictReader
+          # tolerates. Daily connections = the day-over-day delta.
+          header = "date,tool_calls_total,mcp_requests,total_requests,sessions_total"
           f = pathlib.Path("metrics-history.csv")
           lines = f.read_text().splitlines() if f.exists() else [header]
           # Idempotent: drop any existing row for today before appending.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-06-19
+
+### Added
+
+- **`sessions_total` at `/metrics`** — a count of MCP `initialize` calls,
+  a privacy-safe proxy for client connections. It is **not** a user count:
+  a client that reconnects counts again, and automated probes count too. No
+  identity, IP, or request body is stored — the wrapper peeks the small
+  JSON-RPC body only to read the `method`, then replays it to the inner app
+  byte-for-byte. The daily snapshot records it, so day-over-day deltas give
+  "connections/day". Privacy posture in SECURITY.md is unchanged.
+
 ## [0.2.1] — 2026-06-17
 
 A small quality release: sharper AI-coinage detection and a persistent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "Offline MCP server wrapping EstNLTK + EKI Reeglid so AI agents write better Estonian. 21 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -59,7 +59,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.2.1"
+SERVER_VERSION = "0.2.2"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -2603,6 +2603,11 @@ _STATS: dict[str, Any] = {
     "total": 0,
     "by_status": {},
     "by_path": {},
+    # Count of MCP `initialize` calls — a privacy-safe proxy for client
+    # connections / session-starts. NOT a user count: a client that
+    # reconnects counts again, and automated probes count too. No identity,
+    # no IP, no body is stored — only the fact that an initialize occurred.
+    "sessions": 0,
 }
 
 # Ring buffer of recent 5xx errors so they're inspectable at /metrics
@@ -2632,6 +2637,7 @@ def _load_persistent_stats() -> None:
         _STATS["total"] = int(data.get("total", 0))
         _STATS["by_status"] = {str(k): int(v) for k, v in (data.get("by_status") or {}).items()}
         _STATS["by_path"] = {str(k): int(v) for k, v in (data.get("by_path") or {}).items()}
+        _STATS["sessions"] = int(data.get("sessions", 0))
         _TOOL_CALLS.clear()
         _TOOL_CALLS.update({str(k): int(v) for k, v in (data.get("tool_calls") or {}).items()})
         _recent_errors.clear()
@@ -2657,6 +2663,7 @@ def _save_persistent_stats() -> None:
             "total": _STATS["total"],
             "by_status": _STATS["by_status"],
             "by_path": _STATS["by_path"],
+            "sessions": _STATS["sessions"],
             "tool_calls": _TOOL_CALLS,
             "recent_errors": list(_recent_errors),
             "saved_at_unix": int(time.time()),
@@ -2664,6 +2671,60 @@ def _save_persistent_stats() -> None:
         tmp.replace(_METRICS_PATH)
     except Exception as e:
         log.warning("metrics persistence: failed to save %s: %s", _METRICS_PATH, e)
+
+
+def _is_initialize_request(body: bytes) -> bool:
+    """True if an MCP request body is a JSON-RPC `initialize` call.
+
+    Used to count client connections (sessions) at /metrics. We parse only
+    to read the `method` field — never the params/clientInfo — and store
+    nothing from the body. The cheap substring gate skips the JSON parse
+    for the overwhelming majority of requests (tool calls), and parsing
+    the method (rather than substring-matching) means a tool call whose
+    text argument merely contains the word "initialize" is NOT counted."""
+    if b"initialize" not in body:
+        return False
+    try:
+        msg = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return False
+    if isinstance(msg, list):  # JSON-RPC batch
+        return any(isinstance(m, dict) and m.get("method") == "initialize" for m in msg)
+    return isinstance(msg, dict) and msg.get("method") == "initialize"
+
+
+async def _drain_body(receive):
+    """Consume an ASGI HTTP request stream, returning (messages, body).
+
+    `messages` is the exact list of events consumed, so they can be replayed
+    to the inner app unchanged; `body` is the concatenated request body for
+    a one-time peek. Bodies on /mcp are small JSON-RPC payloads."""
+    messages = []
+    body = b""
+    while True:
+        message = await receive()
+        messages.append(message)
+        if message["type"] == "http.request":
+            body += message.get("body", b"")
+            if not message.get("more_body", False):
+                break
+        elif message["type"] == "http.disconnect":
+            break
+    return messages, body
+
+
+def _replay_receive(messages, receive):
+    """Return a receive() that re-emits already-consumed messages in order,
+    then defers to the original receive (e.g. for a later disconnect), so
+    the inner app sees a byte-for-byte-identical request stream."""
+    queue = list(messages)
+
+    async def _receive():
+        if queue:
+            return queue.pop(0)
+        return await receive()
+
+    return _receive
 
 
 def _record_error(path: str, status: int, error: str | None) -> None:
@@ -2888,6 +2949,7 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                     "by_path": dict(_STATS["by_path"]),
                     "tool_calls_total": sum(_TOOL_CALLS.values()),
                     "tool_calls": dict(_TOOL_CALLS),
+                    "sessions_total": _STATS["sessions"],
                     "recent_errors": list(_recent_errors),
                     "uptime_seconds": int(time.time() - _STATS_START_TS),
                     "started_at_unix": int(_STATS_START_TS),
@@ -2895,7 +2957,14 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                         "tool_calls counts ONLY real tool executions (not "
                         "initialize / tools-list / SSE opens, which inflate "
                         "the /mcp path bucket) — use tool_calls_total as the "
-                        "true usage number. Counters persist to "
+                        "true usage number. sessions_total counts MCP "
+                        "initialize calls — a privacy-safe proxy for client "
+                        "connections, NOT a user count: a client that "
+                        "reconnects counts again and automated probes count "
+                        "too. No identity, IP, or request body is ever stored "
+                        "— only the fact of an initialize. Daily connections "
+                        "= the day-over-day delta in the metrics snapshot. "
+                        "Counters persist to "
                         "/data/metrics.json every 30 s when a Fly volume is "
                         "mounted, surviving restarts; without a volume "
                         "(local dev) they reset. Counts are per-Fly-machine, "
@@ -2994,7 +3063,21 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                 await _send_status(send, 429, {"error": "rate_limited"})
                 return
 
-            await inner(scope, receive, send)
+            # Count MCP `initialize` calls as a privacy-safe session proxy.
+            # Only an authorized, non-rate-limited POST /mcp can carry one;
+            # for those we buffer the small JSON-RPC body to peek at the
+            # method, then replay it to the inner app byte-for-byte. Nothing
+            # from the body is stored — only _STATS["sessions"] is bumped on
+            # the fact of an initialize. All other traffic (GET SSE streams,
+            # other paths) passes straight through with the original receive.
+            receive_for_inner = receive
+            if scope.get("method") == "POST" and path in ("/mcp", "/mcp/"):
+                consumed, body = await _drain_body(receive)
+                if _is_initialize_request(body):
+                    _STATS["sessions"] += 1
+                receive_for_inner = _replay_receive(consumed, receive)
+
+            await inner(scope, receive_for_inner, send)
         except Exception as exc:
             # Defence-in-depth. The MCP SDK already converts tool
             # exceptions into JSON-RPC error responses, so reaching here

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -71,6 +71,33 @@ async def boom_inner(scope, receive, send):
     raise RuntimeError("simulated inner-app failure")
 
 
+async def echo_inner(scope, receive, send):
+    """ASGI app that drains the full request body and echoes it back. Used
+    to prove the session-counter's body peek replays the stream byte-for-
+    byte to the inner app."""
+    if scope["type"] == "lifespan":
+        msg = await receive()
+        while msg["type"] != "lifespan.shutdown":
+            if msg["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            msg = await receive()
+        await send({"type": "lifespan.shutdown.complete"})
+        return
+    body = b""
+    while True:
+        msg = await receive()
+        body += msg.get("body", b"")
+        if not msg.get("more_body", False):
+            break
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii"))],
+    })
+    await send({"type": "http.response.body", "body": body})
+
+
 async def run() -> None:
     app = server._build_http_app(TOKEN, rate_limit=5, inner=stub_inner)
     transport = httpx.ASGITransport(app=app)
@@ -114,6 +141,7 @@ async def run() -> None:
         check("metrics has by_path dict", isinstance(body.get("by_path"), dict))
         check("metrics has uptime_seconds", "uptime_seconds" in body)
         check("metrics has recent_errors list", isinstance(body.get("recent_errors"), list))
+        check("metrics has sessions_total int", isinstance(body.get("sessions_total"), int))
 
         print("auth")
         r = await c.post("/mcp", json={})
@@ -224,12 +252,14 @@ def metrics_persistence_test() -> None:
     saved_status = dict(server._STATS["by_status"])
     saved_pathd = dict(server._STATS["by_path"])
     saved_errors = list(server._recent_errors)
+    saved_sessions = server._STATS.get("sessions", 0)
     try:
         with tempfile.TemporaryDirectory() as d:
             server._METRICS_PATH = Path(d) / "metrics.json"
             server._STATS["total"] = 12345
             server._STATS["by_status"] = {"200": 12000, "429": 345}
             server._STATS["by_path"] = {"/mcp": 12300, "/health": 45}
+            server._STATS["sessions"] = 678
             server._recent_errors.clear()
             server._recent_errors.append({"ts": 1700000000, "path": "/mcp", "status": 500, "error": "RuntimeError"})
             server._save_persistent_stats()
@@ -238,11 +268,13 @@ def metrics_persistence_test() -> None:
             server._STATS["total"] = 0
             server._STATS["by_status"] = {}
             server._STATS["by_path"] = {}
+            server._STATS["sessions"] = 0
             server._recent_errors.clear()
             server._load_persistent_stats()
             check("total restored", server._STATS["total"] == 12345)
             check("by_status restored", server._STATS["by_status"] == {"200": 12000, "429": 345})
             check("by_path restored", server._STATS["by_path"] == {"/mcp": 12300, "/health": 45})
+            check("sessions restored", server._STATS["sessions"] == 678, str(server._STATS["sessions"]))
             check("recent_errors restored", list(server._recent_errors) == [
                 {"ts": 1700000000, "path": "/mcp", "status": 500, "error": "RuntimeError"}], str(list(server._recent_errors)))
             # graceful no-op when parent dir is gone (local dev path)
@@ -257,12 +289,60 @@ def metrics_persistence_test() -> None:
         server._STATS["total"] = saved_total
         server._STATS["by_status"] = saved_status
         server._STATS["by_path"] = saved_pathd
+        server._STATS["sessions"] = saved_sessions
         server._recent_errors.clear()
         server._recent_errors.extend(saved_errors)
 
 
+def is_initialize_unit_test() -> None:
+    """Pure checks for the initialize detector — the heart of the session
+    counter. Critically, a tool call whose text merely contains the word
+    'initialize' must NOT be counted."""
+    print("_is_initialize_request (unit)")
+    init = b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"x"}}'
+    check("initialize → True", server._is_initialize_request(init) is True)
+    tool = b'{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spell_check"}}'
+    check("tools/call → False", server._is_initialize_request(tool) is False)
+    sneaky = b'{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"spell_check","arguments":{"text":"please initialize the session"}}}'
+    check("tool call mentioning 'initialize' in text → False",
+          server._is_initialize_request(sneaky) is False)
+    check("empty body → False", server._is_initialize_request(b"") is False)
+    check("malformed JSON → False", server._is_initialize_request(b'{not json initialize') is False)
+    batch = b'[{"jsonrpc":"2.0","id":1,"method":"initialize"},{"jsonrpc":"2.0","method":"ping"}]'
+    check("batch with initialize → True", server._is_initialize_request(batch) is True)
+
+
+async def session_counter_test() -> None:
+    """End-to-end: an initialize POST bumps sessions_total AND the body is
+    replayed to the inner app byte-for-byte; a non-initialize POST does not
+    bump it. Uses echo_inner to prove the replay."""
+    print("session counter")
+    app = server._build_http_app(token=None, rate_limit=100, public_mode=True, inner=echo_inner)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        base = server._STATS["sessions"]
+
+        init_body = {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                     "params": {"protocolVersion": "2025-06-18", "capabilities": {}}}
+        r = await c.post("/mcp", json=init_body)
+        check("initialize → 200", r.status_code == 200, str(r.status_code))
+        check("initialize body replayed to inner verbatim", r.json() == init_body, r.text)
+        check("initialize bumped sessions by 1",
+              server._STATS["sessions"] == base + 1, str(server._STATS["sessions"]))
+
+        call_body = {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                     "params": {"name": "spell_check", "arguments": {"text": "tere"}}}
+        r = await c.post("/mcp", json=call_body)
+        check("tools/call → 200", r.status_code == 200, str(r.status_code))
+        check("tools/call body replayed verbatim", r.json() == call_body, r.text)
+        check("tools/call did NOT bump sessions",
+              server._STATS["sessions"] == base + 1, str(server._STATS["sessions"]))
+
+
 asyncio.run(run())
 metrics_persistence_test()
+is_initialize_unit_test()
+asyncio.run(session_counter_test())
 
 if failures:
     print(f"\n{len(failures)} failure(s):")

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
## Why

You asked "how many daily users?" — and the honest answer was *we don't track that* (aggregate-only metrics, no identity). The best privacy-safe proxy is **counting MCP `initialize` calls**: every client connection sends exactly one. This adds that as `sessions_total`, strictly within the no-tracking posture in SECURITY.md.

## What

- **`sessions_total` at `/metrics`** — cumulative count of `initialize` calls, persisted with the other counters.
- The auth wrapper buffers the small JSON-RPC body of an **authorized, non-rate-limited** `POST /mcp`, peeks **only** the `method` field, increments on `initialize`, then replays the body to the inner app **byte-for-byte** (proven in tests via an echo inner app). Nothing from the body is stored.
- Detection **parses** the method rather than substring-matching, so a tool call whose `text` argument merely contains the word "initialize" is **not** counted.
- The daily snapshot workflow gains a `sessions_total` column → **connections/day = day-over-day delta** (same way we read tool-calls/day).
- Bumped to **0.2.2** (additive, non-breaking) so `/health` stays a reliable post-deploy check.

## Not a user count

`sessions_total` counts *connections*, not people: a client reconnecting counts again, and automated probes (Smithery/monitors hitting `initialize`) count too. The `/metrics` note and CHANGELOG say so. Smithery remains the source of truth for unique installs/users.

## Privacy

No identity, no IP, no request body is stored — only the integer counter is incremented on the *fact* of an initialize. SECURITY.md posture unchanged.

## Tests
- `tests/test_http.py`: initialize bumps `sessions` + body replays verbatim; `tools/call` does not bump + replays verbatim; `_is_initialize_request` unit cases (incl. the "sneaky text" non-count, malformed, batch); persistence round-trip includes `sessions`; `/metrics` exposes `sessions_total`.
- CI's docker job exercises real tool calls over HTTP — the guard that the body-replay change didn't break dispatch.