### PR TITLE
metrics: capture exception type for inner-returned 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-06-29
+
+### Changed
+
+- **Inner-returned 500s now carry an exception type in `recent_errors`.**
+  When the MCP SDK hits an unhandled error in request handling it logs the
+  exception and returns its own 500, so it never reached our wrapper and the
+  `/metrics` breadcrumb showed `error: null` (a blind spot — two such 500s on
+  Jun 21 were unattributable). A small logging handler now captures the
+  exception TYPE name the SDK logs (type only — never the message or
+  traceback) and the ring buffer labels the 500 with it. Best-effort and
+  bounded by a freshness window; PII-free; SECURITY.md posture unchanged.
+
 ## [0.2.2] — 2026-06-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "Offline MCP server wrapping EstNLTK + EKI Reeglid so AI agents write better Estonian. 21 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -59,7 +59,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.2.2"
+SERVER_VERSION = "0.2.3"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -2727,6 +2727,50 @@ def _replay_receive(messages, receive):
     return _receive
 
 
+# When the MCP SDK hits an unhandled error in POST-request handling it logs
+# it via logger.exception(...) and returns its OWN HTTP 500 — the exception
+# never propagates to our wrapper's except block, so those 500s landed in
+# the ring buffer with error=None (a blind spot). We attach a handler to the
+# SDK's logger that stashes ONLY the exception type name (never the message
+# or traceback) the instant it's logged; the send wrapper then borrows it to
+# label an inner-returned 500. The logger.exception() runs synchronously just
+# before the 500 is sent, in the same task, so the slot is fresh and correct
+# for that request. A short freshness window guards against a later 5xx
+# reusing a stale type.
+_last_inner_exc: dict[str, Any] = {"type": None, "ts": 0.0}
+_INNER_EXC_FRESH_SECONDS = 5.0
+
+
+class _InnerExcCapture(logging.Handler):
+    """Records the exception type name from any log record carrying exc_info.
+    Type name only — PII-free, no message, no stack."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        exc_info = record.exc_info
+        if exc_info and exc_info[0] is not None:
+            _last_inner_exc["type"] = exc_info[0].__name__
+            _last_inner_exc["ts"] = time.time()
+
+
+def _install_inner_exc_capture() -> None:
+    """Attach the capture handler to the `mcp` logger once (idempotent).
+    Hooks the parent `mcp` logger so it keeps working if the SDK renames
+    the streamable_http submodule. Additive — does not suppress the SDK's
+    own logging."""
+    lg = logging.getLogger("mcp")
+    if not any(isinstance(h, _InnerExcCapture) for h in lg.handlers):
+        handler = _InnerExcCapture()
+        handler.setLevel(logging.ERROR)
+        lg.addHandler(handler)
+
+
+def _inner_exc_type() -> str | None:
+    """Return the most-recently-logged exception type if fresh, else None."""
+    if _last_inner_exc["type"] and (time.time() - _last_inner_exc["ts"]) < _INNER_EXC_FRESH_SECONDS:
+        return _last_inner_exc["type"]
+    return None
+
+
 def _record_error(path: str, status: int, error: str | None) -> None:
     """Append a PII-free breadcrumb for a 5xx response to the ring buffer."""
     _recent_errors.append({
@@ -2859,6 +2903,9 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
 
     `inner` defaults to FastMCP's streamable-http app; tests inject a stub.
     """
+    # Start capturing the exception type the MCP SDK logs-then-swallows on
+    # an inner 500, so the recent-errors buffer can label it.
+    _install_inner_exc_capture()
     if inner is None:
         from mcp.server.transport_security import TransportSecuritySettings
 
@@ -2894,11 +2941,12 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
             if message["type"] == "http.response.start":
                 status = message.get("status", 0)
                 captured["status"] = status
-                # Record any 5xx — covers both exceptions our wrapper
-                # catches (error type set below) AND 500s the inner MCP
-                # app returns on its own (error stays None).
+                # Record any 5xx. Exceptions our wrapper catches set
+                # captured["error"] below; for a 500 the inner MCP app
+                # returns on its own, borrow the exception type the SDK
+                # logged-then-swallowed (best effort) instead of None.
                 if status >= 500:
-                    _record_error(path, status, captured.get("error"))
+                    _record_error(path, status, captured.get("error") or _inner_exc_type())
             await send_raw(message)
 
         try:
@@ -2975,9 +3023,14 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                         "ring buffer of the last 20 5xx responses (ts, path, "
                         "status, exception type) so failures are inspectable "
                         "here without Fly's short-lived log tail; it persists "
-                        "with the counters. Records tool NAME + count only, "
-                        "never arguments; PII-free; privacy posture in "
-                        "SECURITY.md is unchanged."
+                        "with the counters. The exception type is captured both "
+                        "for errors this wrapper catches and for 500s the MCP "
+                        "SDK returns on its own (borrowed from the type it logs "
+                        "internally); it may still be null if the SDK didn't log "
+                        "a typed exception. Records tool NAME + count and "
+                        "exception TYPE only, never arguments, messages, or "
+                        "tracebacks; PII-free; privacy posture in SECURITY.md is "
+                        "unchanged."
                     ),
                 }
                 await _send_status(send, 200, payload)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -92,6 +93,32 @@ async def echo_inner(scope, receive, send):
     await send({
         "type": "http.response.start",
         "status": 200,
+        "headers": [(b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii"))],
+    })
+    await send({"type": "http.response.body", "body": body})
+
+
+async def logging_boom_inner(scope, receive, send):
+    """Mimics the MCP SDK's inner-500 path: log the exception via the `mcp.*`
+    logger (carrying exc_info) and then return its OWN 500 — the exception
+    does NOT propagate to our wrapper. Verifies we borrow the logged type."""
+    if scope["type"] == "lifespan":
+        msg = await receive()
+        while msg["type"] != "lifespan.shutdown":
+            if msg["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            msg = await receive()
+        await send({"type": "lifespan.shutdown.complete"})
+        return
+    try:
+        raise KeyError("simulated inner protocol error")
+    except Exception:
+        logging.getLogger("mcp.server.streamable_http").exception("Error handling POST request")
+    body = b'{"jsonrpc":"2.0","error":{"code":-32603}}'
+    await send({
+        "type": "http.response.start",
+        "status": 500,
         "headers": [(b"content-type", b"application/json"),
                     (b"content-length", str(len(body)).encode("ascii"))],
     })
@@ -312,6 +339,31 @@ def is_initialize_unit_test() -> None:
     check("batch with initialize → True", server._is_initialize_request(batch) is True)
 
 
+async def inner_exc_capture_test() -> None:
+    """An inner-returned 500 (SDK logs the exception, then returns 500 itself)
+    should be labelled in the ring buffer with the logged exception type,
+    not error=None."""
+    print("inner-500 exception-type capture")
+    server._recent_errors.clear()
+    server._last_inner_exc["type"] = None  # reset the capture slot
+    app = server._build_http_app(token=None, rate_limit=100, public_mode=True,
+                                 inner=logging_boom_inner)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mcp", json={})
+        check("inner 500 status", r.status_code == 500, str(r.status_code))
+        errs = list(server._recent_errors)
+        check("inner 500 recorded in buffer", len(errs) >= 1, str(errs))
+        if errs:
+            last = errs[-1]
+            check("inner 500 labelled with type (not None)",
+                  last.get("error") == "KeyError", str(last))
+            check("inner 500 path/status correct",
+                  last.get("path") == "/mcp" and last.get("status") == 500, str(last))
+    # Stale-guard: an old logged type must not leak onto a later 5xx.
+    server._last_inner_exc["ts"] = 0.0
+    check("stale exception type ignored", server._inner_exc_type() is None)
+
+
 async def session_counter_test() -> None:
     """End-to-end: an initialize POST bumps sessions_total AND the body is
     replayed to the inner app byte-for-byte; a non-initialize POST does not
@@ -343,6 +395,7 @@ asyncio.run(run())
 metrics_persistence_test()
 is_initialize_unit_test()
 asyncio.run(session_counter_test())
+asyncio.run(inner_exc_capture_test())
 
 if failures:
     print(f"\n{len(failures)} failure(s):")

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
## Why

The two Jun 21 500s showed `error: null` in `recent_errors` — unattributable. The cause: when the MCP SDK hits an unhandled error in POST handling it does `logger.exception("Error handling POST request")` and returns its **own** `HTTPStatus.INTERNAL_SERVER_ERROR`. The exception never propagates to our wrapper's `except`, so we recorded the 500 with no type. (Their *specific* cause is unrecoverable — no body was stored and Fly's log retention is long past — but this closes the blind spot for next time.)

## What

A small logging handler attached to the `mcp` logger captures **only the exception type name** the SDK logs (no message, no traceback) into a module slot the instant it's logged. The send wrapper, when recording a 5xx our own `except` didn't already label, borrows that type instead of `null`.

- The SDK's `logger.exception(...)` runs **synchronously, in the same task, immediately before** the 500 is sent — so the slot is fresh and correct for that request.
- A **5s freshness window** guards against a later 5xx reusing a stale type.
- Hooks the parent `mcp` logger (survives a streamable_http submodule rename); **additive** — does not suppress the SDK's own logging.

## Privacy

Type name only. No message, no traceback, no body. SECURITY.md posture unchanged; the `/metrics` note is updated to say so.

## Tests

`tests/test_http.py` gains `logging_boom_inner` — mimics the SDK exactly (logs the exception via `mcp.server.streamable_http`, then returns its own 500 without raising). Asserts the ring buffer labels it `KeyError`, not null, plus a stale-guard check. CI's docker job continues to exercise real tool calls over HTTP.

Release **0.2.3**.