### PR TITLE
Release 0.2.4: security dependency refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-07-04
+
+### Security
+
+- Dependency refresh resolving 15 Dependabot advisories, no API or
+  behaviour change: **starlette** 1.0.1 → 1.3.1 (2 high), **pyjwt**
+  2.12.1 → 2.13.0 (1 high), **python-multipart** 0.0.27 → 0.0.31 (1 high),
+  **cryptography** 48.0.0 → 48.0.1 (1 high), **pydantic-settings** 2.14.0 →
+  2.14.2 (1 medium). One advisory is knowingly left open: **nltk**
+  (GHSA-p4gq-832x-fm9v) has no upstream patch, and its vulnerable
+  `nltk.data.load()` path-traversal is not reachable from user input here
+  (estnltk only ever calls it with a hardcoded resource path) — monitored
+  pending a fix.
+
 ## [0.2.3] — 2026-06-29
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.2.3"
+version = "0.2.4"
 description = "Offline MCP server wrapping EstNLTK + EKI Reeglid so AI agents write better Estonian. 21 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -59,7 +59,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.2.3"
+SERVER_VERSION = "0.2.4"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Version bump so `/health` reflects the security-refreshed build merged in #10–#13, #17.

- `SERVER_VERSION` / `pyproject` / `uv.lock` → **0.2.4**
- CHANGELOG `[0.2.4]` records the 15 resolved advisories (starlette, pyjwt, python-multipart, cryptography, pydantic-settings) and the one knowingly-open nltk advisory (no upstream patch; not in our execution path).

No code/behaviour change — version + changelog only.