### PR TITLE
feat: legal-Estonian tools (check_legalese, check_defined_terms) — 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Run familiarity-verdict tests
         run: uv run --python ${{ matrix.python-version }} python tests/test_familiarity.py
 
+      - name: Run legal-tool tests
+        run: uv run --python ${{ matrix.python-version }} python tests/test_legal.py
+
   docker:
     runs-on: ubuntu-latest
     needs: smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-06
+
+### Added
+
+- **Two legal-Estonian tools (tool count 21 → 23)** — for working with
+  Estonian legal texts, offline and PII-free so confidential documents
+  never leave the machine:
+  - **`check_legalese`** — plain-language simplification aid. Flags archaic
+    'kantseliit' filler (`käesolev` → `see`, `juhul kui` → `kui`) and
+    over-long / over-nested sentences to split, while listing the legal
+    **terms of art** in the text that must be preserved verbatim (a general
+    synonym would change the legal meaning).
+  - **`check_defined_terms`** — structural map for long documents: extracts
+    `(edaspidi «X»)` definitions and their usage, `§` / `lõige` / `punkt`
+    cross-references, and flags defined-but-unused or doubly-defined terms.
+    Input cap raised to 500,000 chars so whole contracts fit.
+
+### Changed
+
+- **`check_compound_familiarity` no longer false-flags legal compounds.** A
+  curated legal terms-of-art list suppresses the ~15% of legal compounds
+  (`õigussuhe`, `solidaarvõlgnik`, `abieluvaraleping`) that the general-web
+  fastText vocabulary mistook for coinages.
+
 ## [0.2.4] — 2026-07-04
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ synonyms instead of inventing them.
 | `check_punctuation(text)` | Kirjavahemärgid — flags missing commas before subordinating conjunctions (`et`, `sest`, `kuna`, `kuid`, `vaid`, `nagu`, …) |
 | `check_hyphenation(word)` | Poolitamine — safe line-break positions for an Estonian word, syllable-boundary based with no-orphan-edge rule |
 | `check_numbers(text)` | Numbrite õigekirjutus — flags decimal separators (`3.14` → `3,14`) and thousands separators (`1,000,000` → `1 000 000`) |
+| `check_legalese(text)` | Legal plain-language aid — flags archaic `kantseliit` filler (`käesolev` → `see`, `juhul kui` → `kui`) and over-long sentences to simplify, while listing the **terms of art** that must be preserved so simplification doesn't change legal meaning |
+| `check_defined_terms(text)` | Long-document structure — maps terms defined with `(edaspidi «X»)`, counts their usage, lists `§` / `lõige` / `punkt` cross-references, and flags defined-but-unused or doubly-defined terms (cap raised to 500k chars) |
 
 POS tag set: `S`=noun, `V`=verb, `A`=adj, `P`=pron, `D`=adv, `K`=adp,
 `J`=conj, `N`=numeral, `I`=interj, `Y`=abbrev, `X`=foreign, `Z`=punct.
@@ -257,7 +259,7 @@ send to suppress it). You'll especially see it right after adding or
 updating the connector, since the client re-checks tools it hasn't
 seen before.
 
-Good news: **all 21 tools are marked `readOnlyHint: true`** (they only
+Good news: **all 23 tools are marked `readOnlyHint: true`** (they only
 read text, never write or call out), so any well-behaved client can
 safely let you allow them once and stop asking:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "estonian-mcp"
-version = "0.2.4"
-description = "Offline MCP server wrapping EstNLTK + EKI Reeglid so AI agents write better Estonian. 21 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk."
+version = "0.3.0"
+description = "Offline MCP server wrapping EstNLTK + EKI Reeglid so AI agents write better Estonian. 23 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = "Apache-2.0"

--- a/server.py
+++ b/server.py
@@ -26,6 +26,7 @@ import collections
 import json
 import logging
 import os
+import re
 import secrets
 import sys
 import time
@@ -45,6 +46,9 @@ from pydantic import Field
 # prompt can't OOM the host or freeze the client.
 MAX_TEXT_CHARS = 100_000
 MAX_WORD_CHARS = 200
+# Structural tools (defined-term / cross-reference tracking) need the whole
+# document at once, and legal texts run long. Parsing is cheap, so allow more.
+MAX_DOC_CHARS = 500_000
 
 # HTTP-mode rate limits.
 # Private mode (bearer auth required): per-token, generous default.
@@ -59,7 +63,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.2.4"
+SERVER_VERSION = "0.3.0"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -136,7 +140,10 @@ SERVER_INSTRUCTIONS = (
     "WordNet synonyms, fastText related words, full inflection paradigms, and "
     "EKI-Reeglid orthography checks (capitalization, compound writing, "
     "commas, number formatting, abbreviation hyphenation), plus object-case, "
-    "register, style, redundancy and calque-risk checks. "
+    "register, style, redundancy and calque-risk checks. For legal Estonian, "
+    "check_legalese aids plain-language simplification while listing the "
+    "terms of art that must be preserved, and check_defined_terms maps "
+    "defined terms and cross-references in long documents. "
     "Use these tools as ground truth rather than guessing Estonian spelling, "
     "case forms, or inflections — language models routinely hallucinate "
     "plausible-but-wrong Estonian morphology. Note that spell_check passing "
@@ -548,6 +555,62 @@ _PLEONASM_PHRASES_ET: dict[tuple[str, ...], str] = {
 }
 
 
+# --- Legal / legalese support --------------------------------------------
+# Curated STARTER lexicons for Estonian legal text. Native speakers are
+# invited to expand these (see CONTRIBUTING) — they are precision-first,
+# not exhaustive.
+
+# Archaic "kantseliit" filler whose plain equivalent does NOT change legal
+# meaning. Matched by surface-prefix so inflected forms are caught. Terms
+# of ART (below) are deliberately NOT here — those must survive simplification.
+_LEGALESE_STEMS_ET: dict[str, tuple[str, str]] = {
+    "käesolev": ("see", "ametlik täitesõna; igapäevakeeles piisab 'see'"),
+    "alljärgnev": ("järgnev", "kantseliit; piisab 'järgnev'"),
+    "eelnimetatud": ("eespool nimetatud", "kantseliit"),
+    "ülalnimetatud": ("eespool nimetatud", "kantseliit"),
+    "eelpoolnimetatud": ("eespool nimetatud", "kantseliit"),
+    "eeltoodu": ("eelnev", "kantseliit"),
+    "tulenevalt": ("tõttu / kuna", "kantseliitlik side; 'sellest tulenevalt' → 'seetõttu'"),
+    "seonduvalt": ("seoses / kohta", "kantseliit"),
+}
+
+# Fixed legalese phrases (lowercased surface pairs) → (plain, why).
+_LEGALESE_PHRASES_ET: dict[tuple[str, str], tuple[str, str]] = {
+    ("juhul", "kui"): ("kui", "'juhul kui' → lihtsalt 'kui'"),
+    ("antud", "juhul"): ("sel juhul", "'antud' on toortõlge (given); 'sel juhul'"),
+    ("sellest", "tulenevalt"): ("seetõttu", "kantseliit; 'seetõttu'"),
+}
+
+# Specialised Estonian legal terms of art. Used to (1) protect them from
+# over-eager simplification, (2) suppress compound-familiarity false
+# 'coinage' flags on legal compounds, (3) mark legal register. STARTER SET.
+_LEGAL_TERMS_OF_ART_ET: frozenset[str] = frozenset({
+    "hagi", "hageja", "kostja", "võlgnik", "võlausaldaja", "võlasuhe",
+    "õigussuhe", "solidaarvõlgnik", "käendus", "käendaja", "menetlus",
+    "kohtumenetlus", "tsiviilkohtumenetlus", "kriminaalmenetlus",
+    "haldusmenetlus", "hagimenetlus", "menetlusosaline", "tõendamiskoormis",
+    "aegumistähtaeg", "sundtäitmine", "kahjuhüvitis", "hüvitamiskohustus",
+    "pandiõigus", "hüpoteek", "servituut", "pärandvara", "pärand", "pärija",
+    "abieluvaraleping", "esindusõigus", "õigusvastane", "seadusjärgne",
+    "tühistatav", "tühine", "riigilõiv", "käsundusleping", "töövõtuleping",
+    "üürileping", "kohtuotsus", "kohtumäärus", "määruskaebus", "tsiviilhagi",
+    "apellatsioonkaebus", "kassatsioonkaebus", "tagaseljaotsus",
+    "tehing", "leping", "kohustus", "nõue", "vastutus", "hüvitis", "tagatis",
+    "testament", "kaashagi", "hagiavaldus", "kohtuistung",
+})
+
+
+def _is_legal_term(word: str) -> bool:
+    """True if a token is a specialised Estonian legal term of art — matched
+    by exact membership or as the head of a legal compound (e.g. hagiavaldus,
+    kohtuistung). Used to protect terms of art and de-noise other tools."""
+    w = word.lower().strip(".,;:()«»„“”\"'")
+    if w in _LEGAL_TERMS_OF_ART_ET:
+        return True
+    # Compound whose first element is a longer legal stem.
+    return any(w.startswith(t) and len(t) >= 6 for t in _LEGAL_TERMS_OF_ART_ET)
+
+
 _COLLOQUIAL_MARKERS: frozenset[str] = frozenset({
     # Discourse particles / interjections of casual speech
     "noh", "nojah", "nojaa", "vot", "ahsoo", "mhm",
@@ -669,6 +732,25 @@ class _RegisterResult(TypedDict, total=False):
 class _CheckResult(TypedDict, total=False):
     """Shared output shape for the issue-list orthography/grammar checks."""
     text: str
+    issues: list[dict]
+    summary_estonian: str
+    note: str
+
+
+class _LegaleseResult(TypedDict, total=False):
+    """Output of check_legalese: simplification hints + terms to preserve."""
+    text: str
+    issues: list[dict]
+    terms_of_art: list[dict]
+    summary_estonian: str
+    note: str
+
+
+class _DefinedTermsResult(TypedDict, total=False):
+    """Output of check_defined_terms: defined-term map + cross-references."""
+    text: str
+    defined_terms: list[dict]
+    cross_references: list[dict]
     issues: list[dict]
     summary_estonian: str
     note: str
@@ -1879,6 +1961,14 @@ def _check_compound_familiarity(text: str) -> dict:
         is_suspect, reasons, quality = _familiarity_verdict(
             in_vocab, top_score, neighbours, parts
         )
+        # De-noise legal register: specialised legal compounds (õigussuhe,
+        # solidaarvõlgnik, abieluvaraleping) are OOV in the general-web
+        # fastText vocab and were false-flagged as coinages (~15% of legal
+        # compounds). A known term of art is real by definition.
+        if is_suspect and _is_legal_term(lemma):
+            is_suspect = False
+            reasons = []
+            quality = {**quality, "legal_term": True}
 
         compounds.append({
             "word": span.text,
@@ -2367,6 +2457,240 @@ def check_redundancy(text: Annotated[str, Field(description="Estonian text to ch
     prose is tight. Input capped at 100,000 characters.
     """
     return _check_redundancy(text)
+
+
+def _check_legalese(text: str) -> dict:
+    """Heuristic Estonian legalese-simplification aid. Flags archaic
+    'kantseliit' filler with plain equivalents, flags over-long/over-nested
+    sentences, and — crucially — lists the legal TERMS OF ART that must be
+    preserved verbatim when simplifying (a general synonym would change the
+    legal meaning)."""
+    _check_text(text)
+    Text = _Text()
+    t = Text(text)
+    t.tag_layer(["sentences", "morph_analysis"])
+    spans = list(t.morph_analysis)
+
+    issues: list[dict] = []
+    terms: list[dict] = []
+    seen: set[str] = set()
+
+    for i, span in enumerate(spans):
+        surface = span.text
+        low = surface.lower()
+        lemma = (_first(list(span.lemma)) or "").lower()
+
+        # Terms of art: preserve, never treat as filler.
+        if _is_legal_term(surface):
+            key = lemma or low
+            if key not in seen:
+                seen.add(key)
+                terms.append({"word": surface, "lemma": lemma or low, "position": span.start})
+            continue
+
+        # Archaic filler (surface-prefix match so inflected forms are caught).
+        for stem, (plain, why) in _LEGALESE_STEMS_ET.items():
+            if low.startswith(stem):
+                issues.append({
+                    "word": surface,
+                    "position": span.start,
+                    "rule": "archaic-filler",
+                    "rule_estonian": "kantseliitlik täitesõna",
+                    "explanation": why,
+                    "suggestion": plain,
+                })
+                break
+
+        # Fixed legalese phrases (adjacent surface pair).
+        if i + 1 < len(spans):
+            pair = (low, spans[i + 1].text.lower())
+            if pair in _LEGALESE_PHRASES_ET:
+                plain, why = _LEGALESE_PHRASES_ET[pair]
+                issues.append({
+                    "phrase": f"{surface} {spans[i + 1].text}",
+                    "position": span.start,
+                    "rule": "legalese-phrase",
+                    "rule_estonian": "kantseliitlik väljend",
+                    "explanation": why,
+                    "suggestion": plain,
+                })
+
+    # Sentence-level complexity: long or heavily-subordinated sentences that
+    # can be split for readability without touching any legal term.
+    for sent in t.sentences:
+        s_text = sent.enclosing_text
+        n_words = len(s_text.split())
+        n_commas = s_text.count(",")
+        if n_words >= 34 or n_commas >= 4:
+            issues.append({
+                "phrase": (s_text[:60] + "…") if len(s_text) > 60 else s_text,
+                "position": sent.start,
+                "rule": "complex-sentence",
+                "rule_estonian": "liiga pikk/keeruline lause",
+                "explanation": (
+                    f"Lause on {n_words} sõna ja {n_commas} koma — kaalu "
+                    f"jagamist lühemateks lauseteks, termineid muutmata."
+                ),
+                "suggestion": "jaga lause lühemateks osadeks",
+            })
+
+    return {
+        "text": text,
+        "issues": issues,
+        "terms_of_art": terms,
+        "summary_estonian": (
+            f"Leiti {len(issues)} lihtsustamiskohta; säilitada tuleb "
+            f"{len(terms)} juriidilist terminit." if (issues or terms)
+            else "Kantseliiti ega juriidilisi termineid ei tuvastatud."
+        ),
+        "note": (
+            "Heuristic legalese-simplification aid. `issues` flags archaic "
+            "'kantseliit' filler (käesolev → see, juhul kui → kui) and "
+            "over-long / over-nested sentences that can be split — WITHOUT "
+            "changing legal meaning. `terms_of_art` lists specialised legal "
+            "terms detected that MUST be preserved verbatim when simplifying: "
+            "replacing e.g. 'vastutus' or 'hagi' with a general synonym would "
+            "change the legal meaning. STARTER lexicons, precision-first and "
+            "not exhaustive — absence of flags is not proof the text is plain, "
+            "and terms_of_art will miss terms not yet in the list. Quote "
+            "rule_estonian verbatim in Estonian replies."
+        ),
+    }
+
+
+# Definition markers: '(edaspidi «Müüja»)', '(edaspidi ühiselt "Pooled")',
+# '(edaspidi nimetatud Leping)'.
+_EDASPIDI_QUOTED_RE = re.compile(
+    r"edaspidi(?:\s+ühiselt)?(?:\s+nimetatud)?\s*[«„\"“]\s*([^»\"”“]+?)\s*[»\"”]",
+    re.IGNORECASE,
+)
+_EDASPIDI_BARE_RE = re.compile(
+    r"edaspidi(?:\s+ühiselt)?(?:\s+nimetatud)?\s+([A-ZÄÖÜÕŠŽ][\wäöüõšžÄÖÜÕŠŽ-]{1,40})",
+)
+_XREF_RE = re.compile(
+    r"(§\s*\d+(?:\s*lg\s*\d+)?|"
+    r"(?:lõige|lõiget|lõikes|lõike|punkt|punkti|punktis|artikkel|artikli)\s+\d+)",
+    re.IGNORECASE,
+)
+
+
+def _count_word_occurrences(term: str, text: str) -> int:
+    """Case-sensitive whole-token occurrence count, Estonian-letter aware
+    (Python \\b is ASCII-only, so use explicit non-letter boundaries)."""
+    pat = r"(?<![\wäöüõšžÄÖÜÕŠŽ])" + re.escape(term) + r"(?![\wäöüõšžÄÖÜÕŠŽ])"
+    return len(re.findall(pat, text))
+
+
+def _check_defined_terms(text: str) -> dict:
+    """Structural aid for LONG legal documents: extract the terms defined
+    with '(edaspidi «X»)', map their usage, extract section cross-references,
+    and flag defined-but-unused or doubly-defined terms. Pure regex, so it
+    scales to whole contracts / statutes (cap raised to MAX_DOC_CHARS)."""
+    _check_text(text, limit=MAX_DOC_CHARS)
+
+    defs: dict[str, dict] = {}
+    for rx in (_EDASPIDI_QUOTED_RE, _EDASPIDI_BARE_RE):
+        for m in rx.finditer(text):
+            term = m.group(1).strip().strip("«»„“”\"' ")
+            if not term:
+                continue
+            d = defs.setdefault(term, {"position": m.start(), "definitions": 0})
+            d["definitions"] += 1
+
+    issues: list[dict] = []
+    defined_terms: list[dict] = []
+    for term, d in sorted(defs.items(), key=lambda kv: kv[1]["position"]):
+        uses = _count_word_occurrences(term, text)
+        defined_terms.append({
+            "term": term, "position": d["position"],
+            "definitions": d["definitions"], "total_occurrences": uses,
+        })
+        if d["definitions"] > 1:
+            issues.append({
+                "term": term, "position": d["position"],
+                "rule": "duplicate-definition",
+                "rule_estonian": "korduv mõistemääratlus",
+                "explanation": f"Mõiste «{term}» on defineeritud {d['definitions']} korda.",
+            })
+        if uses <= d["definitions"]:
+            issues.append({
+                "term": term, "position": d["position"],
+                "rule": "defined-but-unused",
+                "rule_estonian": "kasutamata mõiste",
+                "explanation": f"Mõiste «{term}» on defineeritud, kuid edaspidi tekstis ei kasutata.",
+            })
+
+    xrefs = [{"reference": m.group(0).strip(), "position": m.start()}
+             for m in _XREF_RE.finditer(text)]
+
+    return {
+        "text": text if len(text) <= 2000 else text[:2000] + "…",
+        "defined_terms": defined_terms,
+        "cross_references": xrefs,
+        "issues": issues,
+        "summary_estonian": (
+            f"Leiti {len(defined_terms)} defineeritud mõistet, {len(xrefs)} "
+            f"viidet ja {len(issues)} probleemi."
+        ),
+        "note": (
+            "Structural check for long legal documents. defined_terms maps "
+            "each '(edaspidi «X»)' definition to how many times the term "
+            "actually occurs; cross_references lists § / lõige / punkt / "
+            "artikkel references (surfaced, not validated). issues flags "
+            "defined-but-unused and doubly-defined terms. Regex-based and "
+            "PII-free (nothing stored); input cap is raised to 500,000 chars "
+            "so whole contracts fit. `text` is truncated to a 2,000-char "
+            "preview in the response. Quote rule_estonian verbatim in "
+            "Estonian replies."
+        ),
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(
+    title="Simplify Estonian legalese (keep terms of art)",
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+@_counted
+def check_legalese(text: Annotated[str, Field(description="Estonian legal text to lint for plain-language simplification while protecting legal terms of art.")]) -> _LegaleseResult:
+    """Aid for simplifying Estonian legal text WITHOUT losing legal precision.
+
+    Returns two things:
+    - `issues`: archaic 'kantseliit' filler with plain equivalents
+      (`käesolev` → `see`, `juhul kui` → `kui`), plus over-long / heavily
+      subordinated sentences worth splitting.
+    - `terms_of_art`: specialised legal terms detected in the text that
+      MUST be kept verbatim when rewriting — swapping `hagi` or `vastutus`
+      for a general synonym changes the legal meaning. Use this as a
+      do-not-touch list while you simplify.
+
+    Heuristic, precision-first, backed by curated starter lexicons (not
+    exhaustive). Input capped at 100,000 characters.
+    """
+    return _check_legalese(text)
+
+
+@mcp.tool(annotations=ToolAnnotations(
+    title="Track defined terms & cross-references in a legal document",
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+@_counted
+def check_defined_terms(text: Annotated[str, Field(description="A long Estonian legal document to map defined terms ('edaspidi «X»') and § / lõige / punkt cross-references.")]) -> _DefinedTermsResult:
+    """Structural map of a long Estonian legal document.
+
+    Extracts every term defined with `(edaspidi «X»)`, counts how often each
+    is actually used, lists `§` / `lõige` / `punkt` / `artikkel`
+    cross-references, and flags defined-but-unused or doubly-defined terms —
+    the consistency errors that creep into long contracts and statutes.
+
+    Regex-based and PII-free (nothing is stored). Input cap is raised to
+    500,000 characters so a whole contract fits in one call; the echoed
+    `text` is truncated to a 2,000-character preview.
+    """
+    return _check_defined_terms(text)
 
 
 def _check_style(text: str) -> dict:

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -1,0 +1,129 @@
+"""Tests for the legal-Estonian tools (check_legalese, check_defined_terms).
+
+Both are pure (Vabamorf morphology + regex, no fastText/WordNet), so they run
+locally without the model artifacts. The check_compound_familiarity legal
+de-noise assertion lives in test_smoke.py (it needs the fastText model, which
+only CI has).
+
+Run via:
+
+    uv run python tests/test_legal.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+def legalese_tests() -> None:
+    print("check_legalese")
+    para = ("Käesolevas seaduses sätestatut kohaldatakse võlasuhetele. "
+            "Juhul kui võlgnik ei täida kohustust, tekib võlausaldaja ees "
+            "vastutus ning õigus nõuda kahjuhüvitist.")
+    r = server.check_legalese(para)
+    rules = {i["rule"] for i in r["issues"]}
+    check("flags 'käesolev' archaic filler", "archaic-filler" in rules, str(r["issues"]))
+    check("flags 'juhul kui' phrase", "legalese-phrase" in rules, str(r["issues"]))
+    # käesolev suggestion is the plain 'see'
+    kaes = next((i for i in r["issues"] if i["rule"] == "archaic-filler"), {})
+    check("käesolev → see", kaes.get("suggestion") == "see", str(kaes))
+    # terms of art are surfaced and NOT flagged as filler
+    lemmas = {t["lemma"] for t in r["terms_of_art"]}
+    check("protects legal term võlgnik", "võlgnik" in lemmas, str(lemmas))
+    check("protects several terms of art", len(r["terms_of_art"]) >= 4, str(lemmas))
+    check("no legal term is flagged as filler",
+          not any(server._is_legal_term(i.get("word", "")) for i in r["issues"] if "word" in i),
+          str(r["issues"]))
+
+    # Plain modern Estonian: no archaic-filler flags, no terms of art.
+    clean = server.check_legalese("See on lühike ja selge lause.")
+    check("plain text → no archaic-filler",
+          not any(i["rule"] == "archaic-filler" for i in clean["issues"]), str(clean["issues"]))
+
+    # Over-long sentence → complex-sentence flag.
+    long_s = ("Pool kohustub, arvestades kõiki asjaolusid, tingimusi, tähtaegu "
+              "ja erandeid, mis tulenevad seadusest, lepingust, tavast ning "
+              "kohtupraktikast, täitma oma kohustused nõuetekohaselt, õigel ajal "
+              "ja täies ulatuses ilma põhjendamatu viivituseta.")
+    ls = server.check_legalese(long_s)
+    check("flags over-long sentence", any(i["rule"] == "complex-sentence" for i in ls["issues"]),
+          str([i["rule"] for i in ls["issues"]]))
+
+
+def defined_terms_tests() -> None:
+    print("check_defined_terms")
+    contract = ('Käesoleva lepingu (edaspidi «Leping») pooled on AS Müük '
+                '(edaspidi «Müüja») ja OÜ Ostja (edaspidi «Ostja»). Müüja annab '
+                'kauba üle. Ostja tasub hinna vastavalt Lepingu punkt 3 ja § 5 lg 2. '
+                'Pooled (edaspidi «Pooled») kinnitavad, et Leping jõustub.')
+    d = server.check_defined_terms(contract)
+    defined = {t["term"] for t in d["defined_terms"]}
+    check("extracts «Leping»", "Leping" in defined, str(defined))
+    check("extracts «Müüja» and «Ostja»", {"Müüja", "Ostja"} <= defined, str(defined))
+    xrefs = {x["reference"] for x in d["cross_references"]}
+    check("finds 'punkt 3' cross-ref", any("punkt 3" in x for x in xrefs), str(xrefs))
+    check("finds '§ 5' cross-ref", any(x.startswith("§") for x in xrefs), str(xrefs))
+    # every defined term here is used again → no unused issues
+    check("used terms → no defined-but-unused",
+          not any(i["rule"] == "defined-but-unused" for i in d["issues"]), str(d["issues"]))
+
+    # defined-but-unused detection
+    unused = server.check_defined_terms("Käesolev kokkulepe (edaspidi «Kokkulepe») jõustub täna.")
+    check("flags defined-but-unused",
+          any(i["rule"] == "defined-but-unused" for i in unused["issues"]), str(unused["issues"]))
+
+    # duplicate definition
+    dup = server.check_defined_terms(
+        "Pool (edaspidi «Müüja») ja teine (edaspidi «Müüja»). Müüja tegutseb.")
+    check("flags duplicate-definition",
+          any(i["rule"] == "duplicate-definition" for i in dup["issues"]), str(dup["issues"]))
+
+    # long document under the raised cap does not raise
+    big = "Käesoleva lepingu punkt 1. " * 20000  # ~540k? keep under cap
+    big = big[:server.MAX_DOC_CHARS - 10]
+    try:
+        server.check_defined_terms(big)
+        check("accepts long doc under MAX_DOC_CHARS", True)
+    except Exception as e:
+        check("accepts long doc under MAX_DOC_CHARS", False, str(e))
+    # over the doc cap raises
+    try:
+        server.check_defined_terms("a" * (server.MAX_DOC_CHARS + 1))
+        check("over MAX_DOC_CHARS raises", False, "no exception")
+    except ValueError:
+        check("over MAX_DOC_CHARS raises", True)
+
+
+def is_legal_term_tests() -> None:
+    print("_is_legal_term")
+    check("solidaarvõlgnik is legal", server._is_legal_term("solidaarvõlgnik"))
+    check("inflected võlasuhetele is legal", server._is_legal_term("võlasuhetele"))
+    check("hagiavaldus (compound head) is legal", server._is_legal_term("hagiavaldus"))
+    check("ordinary word 'koer' is not legal", not server._is_legal_term("koer"))
+    check("ordinary word 'ilus' is not legal", not server._is_legal_term("ilus"))
+
+
+legalese_tests()
+defined_terms_tests()
+is_legal_term_tests()
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("\nall legal-tool tests passed")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -227,6 +227,17 @@ if tt:
           and "scrape_junk" in tt["neighbour_quality"], str(tt))
 r = server.check_compound_familiarity("Eile käisin poes ja ostsin leiba.")
 check("no compounds → empty analysis", r["compounds_analysed"] == 0)
+# Legal de-noise: solidaarvõlgnik is a real legal term that used to
+# false-flag as a coinage (OOV in the general-web fastText vocab). The
+# terms-of-art list must suppress that.
+r = server.check_compound_familiarity("Vastutab solidaarvõlgnik.")
+sv = next((c for c in r["all_compounds"] if c["lemma"] == "solidaarvõlgnik"), None)
+check("legal term solidaarvõlgnik analysed", sv is not None,
+      str([c["lemma"] for c in r["all_compounds"]]))
+if sv:
+    check("legal term NOT flagged suspect", sv["is_suspect"] is False, str(sv))
+    check("legal de-noise marked in quality",
+          sv.get("neighbour_quality", {}).get("legal_term") is True, str(sv))
 r = server.check_compound_familiarity(
     "See on mõtteliin."
 )

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Adds Tier 1 of the legal-Estonian plan (Steps 1–2 of the agreed 1→3), grounded in a measured gap report.

## Step 1 — measured gap (why these tools)
Dogfooded ~42 real legal terms + a VÕS §2-style statute paragraph through the current tools:
- **spell_check: 0 flags** — morphology is solid, *not* the gap.
- **WordNet: 83% present but misleading** — general senses, dangerous to offer as "synonyms" for a term of art.
- **check_compound_familiarity: 15% false-flag rate** on legal compounds (`õigussuhe`, `solidaarvõlgnik`, `abieluvaraleping`).
- **check_style: flags 28.6% passive** — a *false* signal; legalese is legitimately passive.
- The biggest gap (canonical usage) isn't even a tool yet → that's Tier 2 (separate PR).

## Step 2 — what this ships (offline, deterministic, PII-free)
- **`check_legalese`** — plain-language aid: flags archaic `kantseliit` filler (`käesolev`→`see`, `juhul kui`→`kui`) and over-long sentences, **and lists the terms of art to preserve** so simplification never changes legal meaning.
- **`check_defined_terms`** — long-doc structure: maps `(edaspidi «X»)` definitions + usage, `§`/`lõige`/`punkt` cross-refs, flags defined-but-unused / doubly-defined. Cap raised to 500k chars.
- **De-noise** — a curated legal terms-of-art list suppresses the measured 15% false coinage flags in `check_compound_familiarity`. (One small asset fixes three things: protects terms, de-noises the coinage tool, and marks legal register.)

Tool count **21 → 23**. Security/lightweight stance unchanged — no new network calls, no model needed for the two new tools (Vabamorf + regex); the offline/PII-free posture is arguably the *selling point* for confidential legal work.

## Tests
- New `tests/test_legal.py` (22 assertions, pure/local) — wired into CI.
- `tests/test_smoke.py` gains the fastText de-noise assertion (`solidaarvõlgnik` not flagged) — runs in CI's docker/smoke with the model.
- Local: test_legal, test_http, test_familiarity all green.

## Notes
- The curated lexicons (`_LEGALESE_STEMS_ET`, `_LEGAL_TERMS_OF_ART_ET`) are **precision-first starter sets** — explicitly inviting native-speaker expansion, like the project's other lexicons.
- Tier 2 (Riigi Teataja "most common usage" collocation index) is the next PR.