### PR TITLE
docs: credit Riigi Teataja + Connectors Directory install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Docs/descriptions now credit **Riigi Teataja** (the public-domain
+  legislation behind `common_legal_usage`) alongside EstNLTK + EKI Reeglid,
+  and note **one-click install from Anthropic's Connectors Directory**.
+  Updated the README intro, `pyproject.toml`, and the GitHub About
+  description (Smithery listing is a manual dashboard field).
+
 ## [0.4.1] — 2026-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@
 
 A small **Model Context Protocol** server that exposes
 [EstNLTK](https://github.com/estnltk/estnltk) — the Estonian NLP toolkit —
-as tools any LLM client can call in real time. Hand it Estonian text,
-get back correct lemmas, morphology, POS tags, spell-check + suggestions,
-syllables, named entities, WordNet synonyms, fastText-based related
-words, and a register hint (formal vs colloquial).
+as tools any LLM client can call in real time, backed by EKI's orthography
+rules (Reeglid) and public-domain Riigi Teataja legislation. Hand it
+Estonian text, get back correct lemmas, morphology, POS tags, spell-check +
+suggestions, syllables, named entities, WordNet synonyms, fastText-based
+related words, a register hint, orthography/grammar checks, and — for legal
+texts — legalese simplification and canonical legal-usage lookups.
+
+**One-click install** from Anthropic's official Connectors Directory, or
+self-host — see below.
 
 If your AI agent has to draft, edit, or proofread Estonian, this wires
 in ground truth so it stops guessing on the mechanical layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "estonian-mcp"
 version = "0.4.1"
-description = "Offline MCP server wrapping EstNLTK + EKI Reeglid so AI agents write better Estonian. 24 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
+description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 24 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = "Apache-2.0"


### PR DESCRIPTION
Keeps the public-facing writing an accurate mirror of what the MCP does and is built on.

- **Credit Riigi Teataja** — `common_legal_usage` is built from public-domain Riigi Teataja legislation, so it now sits alongside EstNLTK + EKI Reeglid in the README intro and `pyproject.toml` description (NOTICE already credited it).
- **Connectors Directory** — accepted into Anthropic's official directory → one-click install across all Claude apps; noted in the README intro.
- GitHub About description already updated live; the Smithery listing is a manual dashboard field for the user.

Docs only, no code/behaviour change.