### PR TITLE
Release 0.4.2: security dependency refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.2] — 2026-07-18
+
+### Security
+
+- Dependency refresh resolving 6 high-severity Dependabot advisories, no
+  API or behaviour change: **mcp** 1.27.0 → 1.28.1 (3 high — the core MCP
+  SDK), **nltk** 3.9.4 → 3.10.0 (1 high — the `nltk.data.load()`
+  path-traversal previously left open for lack of an upstream patch, now
+  fixed and no longer just monitored), **soupsieve** 2.8.3 → 2.8.4 (2 high).
+
 ### Changed
 
 - Docs/descriptions now credit **Riigi Teataja** (the public-domain

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.4.1"
+version = "0.4.2"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 24 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -63,7 +63,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.4.1"
+SERVER_VERSION = "0.4.2"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Version bump so `/health` reflects the security-refreshed build merged in #21/#25/#27.

- `SERVER_VERSION` / `pyproject` / `uv.lock` → **0.4.2**
- CHANGELOG `[0.4.2]` records the 6 resolved HIGH advisories (mcp ×3, nltk ×1, soupsieve ×2) — notably the **nltk path-traversal** we'd been monitoring for lack of a patch is now fixed.

No code/behaviour change — version + changelog only.