### PR TITLE
favicon: immutable cache + ETag/304; README leads with Connectors Directory (0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.3] — 2026-07-20
+
+### Changed
+
+- **Static icons now serve a 1-year immutable cache + ETag with `304 Not
+  Modified` handling.** A client ignoring the existing cache header had been
+  re-fetching `/favicon.svg` in a loop (~65% of all requests — most likely
+  connector-directory icon rendering); conditional and well-behaved clients
+  now stop re-downloading. Cheap, no functional change.
+- **README getting-started reflects the Connectors Directory.** Now that
+  estonian-mcp is in Anthropic's official directory, the install flow leads
+  with one-click from the directory; pasting the custom URL is the fallback.
+
 ## [0.4.2] — 2026-07-18
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ synonyms instead of inventing them.
 
 **Three ways to use it:**
 
-1. 👉 **Paste a URL into your Claude app** — the easiest path, no
-   terminal, no install. See [Get started in 30 seconds](#-get-started-in-30-seconds-no-install) below.
+1. 👉 **One-click from Anthropic's Connectors Directory** — the easiest
+   path, no terminal, no install, no URL to paste. See
+   [Get started in 30 seconds](#-get-started-in-30-seconds-no-install) below.
 2. **One-click on Smithery** — install from the
    [estonian-mcp listing](https://smithery.ai/servers/silly-geese/estonian-mcp).
 3. **Self-host** — clone, run locally as stdio, or deploy your own
@@ -81,47 +82,36 @@ POS tag set: `S`=noun, `V`=verb, `A`=adj, `P`=pron, `D`=adv, `K`=adp,
 This section is for everyone — including if you've never opened a
 terminal in your life. You'll be done before your tea is steeped.
 
-The trick is that we run the server for you on the public internet at
-`https://estonian-mcp.fly.dev/mcp`. You just need to tell your Claude
-app to talk to it. Pick the app you use:
+**estonian-mcp is in Anthropic's official Connectors Directory**, so on
+most Claude apps you can add it with **one click — no URL to paste, no
+config, no auth.**
 
-### In Claude Cowork
+### One-click from the Connectors Directory (Cowork, claude.ai, Claude Desktop)
 
-1. Open Cowork and click your profile / **Settings**.
-2. Find **Connectors** in the sidebar.
-3. Click **Add custom connector**.
-4. Paste this URL into the URL field:
-   ```
-   https://estonian-mcp.fly.dev/mcp
-   ```
-5. Leave any "Authentication" / "API key" / "Bearer token" fields
-   **empty**. The server is public — no token needed.
-6. Click **Save** / **Connect**.
-7. Done. Start a new chat and write in Estonian — proofread an
-   email, study a paragraph, draft a reply. Claude will reach for
-   the EstNLTK tools whenever it needs to verify spelling, lemmas,
-   or morphology rather than guessing.
+1. In your Claude app, open **Settings → Connectors**.
+2. **Browse connectors** (the directory) and search **estonian-mcp**.
+3. Click **Add** / **Connect**. That's it — the server is public, so
+   there's no authentication step.
+4. Start a new chat and write in Estonian — proofread an email, study a
+   paragraph, draft a legal clause. Claude reaches for the tools whenever
+   it needs to verify spelling, lemmas, morphology, or legal phrasing
+   rather than guessing.
 
-### In claude.ai (web Claude)
+*(On older Claude Desktop without a Connectors menu, use the stdio path in
+[Self-host (advanced)](#self-host-advanced).)*
 
-1. Click your profile in the bottom-left → **Settings**.
-2. Find **Connectors** (sometimes called **Custom Integrations**).
-3. Click **Add custom connector**.
-4. Paste:
-   ```
-   https://estonian-mcp.fly.dev/mcp
-   ```
-5. Authentication: **none** (leave fields blank).
-6. Save. The new tools appear in your tool tray.
+### Prefer to paste the URL? (or don't see it in the directory yet)
 
-### In Claude Desktop
+Any MCP-over-HTTPS client can also connect directly to the hosted server —
+we run it for you at `https://estonian-mcp.fly.dev/mcp`. In **Settings →
+Connectors → Add custom connector**, paste:
 
-If your Claude Desktop has a **Settings → Connectors** menu (newer
-versions), follow the same three steps as Cowork above.
+```
+https://estonian-mcp.fly.dev/mcp
+```
 
-If it doesn't, you have an older Desktop that needs a JSON config
-file edit — see [Self-host (advanced)](#self-host-advanced) for the
-local-stdio path, which works on every version.
+Leave every "Authentication" / "API key" / "Bearer token" field **empty**
+— the server is public, no token needed — and Save.
 
 ### In Claude Code (CLI)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ config, no auth.**
 ### One-click from the Connectors Directory (Cowork, claude.ai, Claude Desktop)
 
 1. In your Claude app, open **Settings → Connectors**.
-2. **Browse connectors** (the directory) and search **estonian-mcp**.
+2. **Browse connectors** (the directory) and search **estonian** — it
+   shows up as the Estonian connector.
 3. Click **Add** / **Connect**. That's it — the server is public, so
    there's no authentication step.
 4. Start a new chat and write in Estonian — proofread an email, study a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.4.2"
+version = "0.4.3"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 24 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import base64
 import collections
+import hashlib
 import json
 import logging
 import os
@@ -63,7 +64,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.4.2"
+SERVER_VERSION = "0.4.3"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -94,6 +95,14 @@ try:
     FAVICON_PNG: bytes | None = _LOGO_PNG_PATH.read_bytes()
 except OSError:
     FAVICON_PNG = None
+
+# Content-hash ETags for the static icons so conditional requests can be
+# answered with a bodyless 304 instead of re-sending the bytes. The icons
+# are fixed per build, so a hash of the bytes is a stable validator.
+_FAVICON_SVG_ETAG = '"' + hashlib.md5(FAVICON_SVG).hexdigest()[:16] + '"'
+_FAVICON_PNG_ETAG = (
+    '"' + hashlib.md5(FAVICON_PNG).hexdigest()[:16] + '"' if FAVICON_PNG else None
+)
 
 # Minimal HTML landing page at /. Two purposes:
 # 1. Google's favicon scraper fetches / first and parses <link rel="icon">
@@ -3312,6 +3321,37 @@ async def _send_status(send, status: int, body: dict[str, Any]) -> None:
     await send({"type": "http.response.body", "body": payload})
 
 
+async def _serve_static_icon(send, scope, body: bytes, content_type: bytes, etag: str) -> None:
+    """Serve a static icon with a 1-year immutable cache + ETag. If the
+    client already holds this version (If-None-Match), answer 304 with no
+    body. Cheap defence against clients that re-fetch the favicon in a loop
+    (e.g. connector-directory icon rendering) — anything honouring either
+    caching or conditional requests stops re-downloading."""
+    if_none_match = ""
+    for k, v in scope.get("headers", []):
+        if k == b"if-none-match":
+            if_none_match = v.decode("latin1")
+            break
+    cache_headers = [
+        (b"cache-control", b"public, max-age=31536000, immutable"),
+        (b"etag", etag.encode("ascii")),
+    ]
+    if etag in if_none_match or if_none_match.strip() == "*":
+        await send({"type": "http.response.start", "status": 304, "headers": cache_headers})
+        await send({"type": "http.response.body", "body": b""})
+        return
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [
+            (b"content-type", content_type),
+            (b"content-length", str(len(body)).encode("ascii")),
+            *cache_headers,
+        ],
+    })
+    await send({"type": "http.response.body", "body": body})
+
+
 async def _send_redirect(send, location: str) -> None:
     await send({
         "type": "http.response.start",
@@ -3501,30 +3541,14 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
             # + Claude tool-call UI. /favicon.svg keeps SVG for modern
             # browsers.
             if path in ("/favicon.ico", "/favicon.png") and FAVICON_PNG is not None:
-                await send({
-                    "type": "http.response.start",
-                    "status": 200,
-                    "headers": [
-                        (b"content-type", b"image/png"),
-                        (b"content-length", str(len(FAVICON_PNG)).encode("ascii")),
-                        (b"cache-control", b"public, max-age=86400"),
-                    ],
-                })
-                await send({"type": "http.response.body", "body": FAVICON_PNG})
+                await _serve_static_icon(
+                    send, scope, FAVICON_PNG, b"image/png", _FAVICON_PNG_ETAG)
                 return
             if path == "/favicon.svg" or (
                 path == "/favicon.ico" and FAVICON_PNG is None
             ):
-                await send({
-                    "type": "http.response.start",
-                    "status": 200,
-                    "headers": [
-                        (b"content-type", b"image/svg+xml"),
-                        (b"content-length", str(len(FAVICON_SVG)).encode("ascii")),
-                        (b"cache-control", b"public, max-age=86400"),
-                    ],
-                })
-                await send({"type": "http.response.body", "body": FAVICON_SVG})
+                await _serve_static_icon(
+                    send, scope, FAVICON_SVG, b"image/svg+xml", _FAVICON_SVG_ETAG)
                 return
 
             # Smithery + similar registries probe this for auto-discovery.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -159,6 +159,19 @@ async def run() -> None:
         check("/sse → 404", r.status_code == 404, str(r.status_code))
         check("/sse points to /mcp", r.json().get("endpoint") == "/mcp", str(r.json()))
 
+        print("favicon caching (ETag / 304)")
+        r = await c.get("/favicon.svg")
+        check("favicon.svg → 200", r.status_code == 200, str(r.status_code))
+        check("favicon.svg is svg", r.headers.get("content-type") == "image/svg+xml")
+        etag = r.headers.get("etag")
+        check("favicon.svg has ETag", bool(etag), str(r.headers))
+        check("favicon.svg immutable cache",
+              "immutable" in (r.headers.get("cache-control") or ""), r.headers.get("cache-control"))
+        # Conditional re-fetch with the ETag → 304, no body.
+        r2 = await c.get("/favicon.svg", headers={"If-None-Match": etag})
+        check("favicon.svg conditional → 304", r2.status_code == 304, str(r2.status_code))
+        check("304 has empty body", not r2.content, repr(r2.content[:20]))
+
         print("metrics")
         r = await c.get("/metrics")
         check("metrics 200", r.status_code == 200)

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
## Favicon caching (the /favicon.svg surge)
Production metrics showed **~65% of all requests were `/favicon.svg`** and escalating (125k → 219k/day). It already had a 1-day cache header, so the source is a client **ignoring caching** — timing points at connector-directory / Claude-client icon rendering. Harmless (tiny SVG, all 200s, no errors) but wasteful.

Fix: static icons now serve `cache-control: public, max-age=31536000, immutable` + a content-hash **ETag**, and answer conditional requests with a bodyless **304**. Anything honouring *either* caching or conditional requests stops re-downloading. (If the offender ignores both, this won't fully stop it — but it's correct hygiene and the traffic is harmless; rate-limiting the asset would be the next lever only if it becomes a bandwidth cost.)

## README — now that we're in the Connectors Directory
Getting-started **leads with one-click from Anthropic's official directory** (search `estonian-mcp` → Add); the custom-URL paste is reframed as the fallback, and the repetitive per-client steps are consolidated. Updated the "three ways to use it" list too.

## Tests
`tests/test_http.py` covers 200 → ETag/immutable → conditional 304. All local suites green. Bump to **0.4.3**.

Docs + a small static-serving change; deploy-worthy so `/health` shows 0.4.3.