### PR TITLE
Release 0.4.4: pillow security refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.4] — 2026-07-29
+
+### Security
+
+- Dependency refresh resolving 13 Dependabot advisories (11 high, 2 medium),
+  no API or behaviour change: **pillow** 12.2.0 → 12.3.0. Pillow is a
+  transitive dev/eval dependency (via matplotlib) that the running server
+  never invokes, so the advisories were not in the exploitable path. This
+  patches it regardless and makes `/health` reflect the refreshed build.
+
 ## [0.4.3] — 2026-07-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.4.3"
+version = "0.4.4"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 24 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.4.3"
+SERVER_VERSION = "0.4.4"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Version bump so `/health` reflects the security-refreshed build merged in #31.

- `SERVER_VERSION` / `pyproject` / `uv.lock` -> **0.4.4**
- CHANGELOG `[0.4.4]` records the 13 resolved pillow advisories (11 high, 2 medium). Pillow is a transitive dev/eval dep (via matplotlib) the server never invokes, so not in the exploitable path; patched regardless.

No code/behaviour change. Version + changelog only.