### PR TITLE
Release 0.5.0: editorial tools (check_officialese, check_term_consistency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run legal-tool tests
         run: uv run --python ${{ matrix.python-version }} python tests/test_legal.py
 
+      - name: Run officialese / term-consistency tests
+        run: uv run --python ${{ matrix.python-version }} python tests/test_officialese.py
+
   docker:
     runs-on: ubuntu-latest
     needs: smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,94 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-07-31
+
+Editorial release. Everything here came out of replaying a real Estonian
+editing conversation through the server: a native speaker rewriting an
+R&D report for readability, asking "is this the right word here?", and
+being told `korpus` is wrong for image data. The MCP was never invoked
+in that conversation, and when the text was replayed through the tools,
+most of them stayed silent or gave the wrong verdict. 24 tools → 26.
+
+### Added
+
+- **`check_officialese(text)` — kantseliit check for NON-legal Estonian.**
+  `check_legalese` exists but is scoped to statutes: on a real R&D report
+  paragraph it returned zero issues, because its filler lexicon is
+  legal-specific and its 34-word gate sits above where Estonian prose
+  actually becomes unreadable. The new tool measures nominalisation
+  density (each `-mine` noun paired with the verb to swap in,
+  `hindamine` → `hindama`), correctly-counted umbisikuline tegumood,
+  clause stacking (`mille käigus … ning …`, which a raw word count
+  misses), an Estonian-calibrated 25-word sentence gate, and
+  administrative filler (`omab` → `on`, `kujutab endast` → `on`,
+  `viidi läbi` → `tehti`, `mudeli poolt loodud` → `mudeli loodud`).
+  Thresholds are calibrated against a native speaker's own rewrite of
+  the report: impersonal ratio 0.875 → 0.308, `-mine` per 100 words
+  7.89 → 2.33, longest sentence 30 → 21 words. The bureaucratic
+  original flags; the human rewrite comes back clean.
+- **`check_term_consistency(text)` — one referent, one term.** The
+  long-document defect a model editing paragraph-by-paragraph reliably
+  misses: a dataset that is `andmestik` on page 1, `teadusandmestik` on
+  page 2 and `pildiandmestik` on page 3. Two precision-first rules —
+  shared compound head, and shared Estonian WordNet synset — with
+  per-variant counts so you can standardise on the dominant term. Two
+  compounds sharing a head is deliberately *not* enough to flag, since
+  those are usually distinct things. Known gap, stated in the tool's own
+  note: synonyms sharing neither a head nor a synset (`korpus` /
+  `andmestik`) are not caught.
+
+### Fixed
+
+- **`check_style` mis-counted umbisikuline tegumood four ways**, all
+  verified against Vabamorf tags on real text. `ei` / `ära` are tagged
+  `pos=V form=neg`, so every negation inflated `total_verbs` and
+  *deflated* the ratio. The `ta` / `da` impersonal-present-negative form
+  (`ei esitata`) was absent from the form set and missed entirely.
+  `ei avaldatud` is tagged `pos=A`, not `V`, and was skipped. And
+  attributive `-tud` participles (`lukustatud hindamisosa` — a modifier,
+  not a predicate) were counted as passive; they now appear under
+  `attributive_excluded` instead. The counter is shared with the two new
+  tools, so all three agree.
+- **`check_compound_familiarity`'s junk-neighbour gate inverted human
+  judgement.** `pildiandmestik` — whose top fastText neighbour is its own
+  head `andmestik` at 0.71 — was flagged suspect purely because 5/8 of
+  the neighbour *tail* was scrape junk, while `teadusandmestik` (0.705),
+  the word a native speaker called artificial, passed. The junk gate is
+  now decisive only when the compound is also weak at the top (< 0.60)
+  or its top neighbour is itself junk; a clean, real, ≥ 0.60 top
+  neighbour vouches for the compound whatever the tail looks like.
+  `mõtteliin` and `toortõlkeoht` still flag. The tool note now states the
+  converse limit explicitly: similarity cannot judge register, so a
+  well-formed but *stilted* compound will pass.
+
+### Changed
+
+- **`classify_register` scored dense officialese as `neutraalne`, 0.0,
+  with zero markers** — while 87.5% of that text's verbs were
+  impersonal. Two fixes: the lexicon gains academic/report vocabulary
+  (`aruandeperiood`, `ettevõttesiseselt`, `valideerima`, `metoodika`,
+  …), and a new `structure` block folds in umbisikuline tegumood ratio
+  and noun/verb density. The structural component is bounded at +0.4 and
+  applies only from 25 words up and only when the lexicon is not
+  net-colloquial, so short strings still score purely on the lexicon and
+  chatty copy can never be nudged formal.
+- **`synonyms` now documents the word-fit check.** The server already
+  knew that `korpus` means "kirjaliku või suulise teksti elektrooniline
+  kogu" — the exact fact that settles whether a set of images can be
+  called one — but returned it as one of five unranked senses with
+  nothing telling the model to test the gloss against context. The
+  docstring now says to read each `definition` for its domain constraint
+  when the question is "is this the right word here?".
+- **Server instructions name the editorial use case.** Every tool was
+  named for a *mechanical* check, so models didn't reach for the server
+  on "is this the right word" or "make this read more human". The
+  `initialize` instructions now route those questions explicitly.
+- `estonian-writing-assistant` skill: two new workflows (de-bureaucratise
+  Estonian prose; "is this the right word here?"), the new tools in the
+  table, and a corrected `check_compound_familiarity` threshold (the
+  skill still documented the old 0.55 gate).
+
 ## [0.4.4] — 2026-07-29
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,11 @@ most of them stayed silent or gave the wrong verdict. 24 tools → 26.
   neighbour vouches for the compound whatever the tail looks like.
   `mõtteliin` and `toortõlkeoht` still flag. The tool note now states the
   converse limit explicitly: similarity cannot judge register, so a
-  well-formed but *stilted* compound will pass.
+  well-formed but *stilted* compound will pass. Relatedly, the
+  `neighbour_quality.legal_term` marker is now stamped for every known
+  term of art rather than only for ones whose verdict had to be rescued —
+  with the guard in place, `solidaarvõlgnik` clears on its own merits but
+  callers still want to know it is attested legal vocabulary.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ as tools any LLM client can call in real time, backed by EKI's orthography
 rules (Reeglid) and public-domain Riigi Teataja legislation. Hand it
 Estonian text, get back correct lemmas, morphology, POS tags, spell-check +
 suggestions, syllables, named entities, WordNet synonyms, fastText-based
-related words, a register hint, orthography/grammar checks, and, for legal
-texts, legalese simplification and canonical legal-usage lookups.
+related words, a register hint, orthography/grammar checks, kantseliit and
+terminology-consistency checks for reports and academic prose, and, for
+legal texts, legalese simplification and canonical legal-usage lookups.
 
 **One-click install** from Anthropic's official Connectors Directory, or
 self-host. See below.
@@ -24,6 +25,14 @@ If your AI agent has to draft, edit, or proofread Estonian, this wires
 in ground truth so it stops guessing on the mechanical layer
 (spelling, case forms, conjugation) and gives it real Estonian
 synonyms instead of inventing them.
+
+It also covers the **editorial** layer, where a word can be correctly
+spelled, morphologically valid and still wrong: `check_officialese` for
+bureaucratic Estonian in reports and academic prose, `check_term_consistency`
+for a document that names one thing three ways, and `synonyms` read as a
+word-fit check — its glosses carry domain constraints (`korpus` is
+specifically "kirjaliku või suulise teksti elektrooniline kogu", so a set
+of images is not one, however natural it sounds in ML jargon).
 
 > **Benchmark:** on TalTech's [`inflection_et`](https://huggingface.co/datasets/TalTechNLP/inflection_et)
 > gold dataset (a noun-phrase inflection benchmark; Lillepalu & Alumäe,
@@ -57,8 +66,10 @@ synonyms instead of inventing them.
 | `named_entities(text)` | People / places / organisations |
 | `synonyms(word)` | Synsets from Estonian WordNet, synonymous lemmas + definition + examples per word sense |
 | `find_related_words(word)` | Top-N semantically nearby words via fastText embeddings (semantically related, not always synonymous) |
-| `classify_register(text)` | Coarse formal/colloquial register hint with matched markers + consistency flag for register-mixed text (heuristic, phase 1) |
-| `check_style(text)` | Style metrics, lemma-aware repetition, passive-voice ratio, sentence-length variance, hedging-word density |
+| `classify_register(text)` | Coarse formal/colloquial register hint with matched markers, consistency flag for register-mixed text, plus structural signals (umbisikuline tegumood ratio, noun density) so dense officialese no longer scores "neutral" |
+| `check_style(text)` | Style metrics, lemma-aware repetition, umbisikuline-tegumood ratio, sentence-length variance, hedging-word density |
+| `check_officialese(text)` | Kantseliit check for **non-legal** prose (reports, academic, business), where `check_legalese` stays silent. Nominalisation density (`hindamine` → `hindama`), impersonal-voice ratio, clause stacking (`mille käigus … ning …`), Estonian-calibrated sentence length, and admin filler (`omab` → `on`, `viidi läbi` → `tehti`, `mudeli poolt loodud` → `mudeli loodud`) |
+| `check_term_consistency(text)` | One referent, one term. Flags a document that calls the same thing `andmestik` on page 1 and `teadusandmestik` on page 2, via shared compound head or shared Estonian WordNet synset, with per-variant counts so you can standardise on the dominant one |
 | `check_redundancy(text)` | Pleonasm check, flags semantic doubling like `samuti ka` (also+also), `kõige optimaalsem` (most+optimal), and fixed redundant phrases |
 | `check_object_case(text)` | Käändeõpetus, flags direct-object case errors under negation and after partitive-only verbs (armastama, vihkama, vajama, …) |
 | `check_abbreviation_hyphenation(text)` | Lühendiortograafia, flags abbreviations with case endings missing the EKI-mandated hyphen (`MCPst` → `MCP-st`, `OÜle` → `OÜ-le`) |
@@ -258,7 +269,7 @@ send to suppress it). You'll especially see it right after adding or
 updating the connector, since the client re-checks tools it hasn't
 seen before.
 
-Good news: **all 24 tools are marked `readOnlyHint: true`** (they only
+Good news: **all 26 tools are marked `readOnlyHint: true`** (they only
 read text, never write or call out), so any well-behaved client can
 safely let you allow them once and stop asking:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "estonian-mcp"
-version = "0.4.4"
-description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 24 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
+version = "0.5.0"
+description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = "Apache-2.0"

--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.4.4"
+SERVER_VERSION = "0.5.0"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -161,7 +161,19 @@ SERVER_INSTRUCTIONS = (
     "does NOT prove a word is real Estonian: Vabamorf accepts any "
     "morphologically valid compound, including ones you just coined, so "
     "verify coined or unusual compounds with check_compound_familiarity "
-    "before using them. All tools are read-only and "
+    "before using them. "
+    "REACH FOR THESE TOOLS ON EDITORIAL QUESTIONS TOO, not just mechanical "
+    "ones. 'Is this the right word here?' → synonyms, and read each "
+    "definition's domain constraint against the context rather than "
+    "trusting the word's ML-jargon familiarity. 'Make this read more "
+    "human' / 'this is too bureaucratic' → check_officialese for "
+    "kantseliit in reports, academic and business prose (check_legalese "
+    "is for statutes and stays silent on those), plus check_style for "
+    "umbisikuline tegumood and rhythm. 'Keep the terminology "
+    "consistent across this document' → check_term_consistency. A word "
+    "can be correctly spelled, morphologically valid and still the wrong "
+    "register or the wrong term for its domain — the mechanical checks "
+    "will not tell you that. All tools are read-only and "
     "operate on Estonian text; results are returned in UTF-8 (preserve "
     "õ/ä/ö/ü/š/ž)."
 )
@@ -607,6 +619,81 @@ _LEGALESE_PHRASES_ET: dict[tuple[str, str], tuple[str, str]] = {
     ("sellest", "tulenevalt"): ("seetõttu", "kantseliit; 'seetõttu'"),
 }
 
+# ---------------------------------------------------------------------------
+# Officialese (kantseliit) lexicons — the NON-legal sibling of the legalese
+# set above. Aimed at reports, academic prose, grant/R&D paperwork and
+# business writing, where check_legalese finds nothing because its lexicon
+# is legal-specific and its length gate is tuned for statutes.
+#
+# Matched on LEMMA (exact), not surface prefix: prefix matching would fire
+# on 'oma'/'omadus' for the 'omama' entry. Precision-first, per repo
+# convention — a missed flag costs less than a wrong one.
+# ---------------------------------------------------------------------------
+
+_OFFICIALESE_LEMMAS_ET: dict[str, tuple[str, str]] = {
+    "omama": ("olema", "'omab tähtsust' → 'on tähtis'; 'omama' on kantseliitlik tugiverb"),
+    "teostama": ("tegema (või konkreetne tegusõna)", "kantseliitlik tugiverb; 'teostada analüüs' → 'analüüsida'"),
+    "lähtuvalt": ("järgi / põhjal", "kantseliitlik side"),
+    "tingituna": ("tõttu", "kantseliit; 'tõttu' on lihtsam"),
+    "johtuvalt": ("tõttu", "kantseliit; 'tõttu' on lihtsam"),
+    "olemasolu": ("on olemas", "nimisõnastatud olemine; kasuta tegusõna"),
+}
+
+# Officialese matched on SURFACE form, not lemma. For these the specific
+# inflected form is the marker while the lemma is an ordinary word:
+# `eesmärgil` lemmatises to `eesmärk` and `vahendusel` to `vahendus`, so
+# keying on the lemma would fire on every innocent "meie eesmärk on …".
+_OFFICIALESE_SURFACE_ET: dict[str, tuple[str, str]] = {
+    "eesmärgil": ("et + tegusõna", "kantseliit; 'analüüsi eesmärgil' → 'et analüüsida'"),
+    "vahendusel": ("kaudu / abil", "kantseliit; 'süsteemi vahendusel' → 'süsteemi kaudu'"),
+}
+
+# Fixed officialese phrases (lowercased surface pairs) → (plain, why).
+_OFFICIALESE_PHRASES_ET: dict[tuple[str, str], tuple[str, str]] = {
+    ("kujutab", "endast"): ("on", "kantseliit; piisab tegusõnast 'on'"),
+    ("kujutavad", "endast"): ("on", "kantseliit; piisab tegusõnast 'on'"),
+    ("viidi", "läbi"): ("tehti / korraldati", "tugiverb 'läbi viima'; kasuta konkreetset tegusõna"),
+    ("viiakse", "läbi"): ("tehakse / korraldatakse", "tugiverb 'läbi viima'; kasuta konkreetset tegusõna"),
+    ("läbi", "viia"): ("teha / korraldada", "tugiverb 'läbi viima'; kasuta konkreetset tegusõna"),
+    ("läbi", "viidud"): ("tehtud / korraldatud", "tugiverb 'läbi viima'; kasuta konkreetset tegusõna"),
+    ("selles", "osas"): ("selle kohta", "kantseliitlik 'osas'; 'kohta' on lihtsam"),
+    ("selle", "osas"): ("selle kohta", "kantseliitlik 'osas'; 'kohta' on lihtsam"),
+    ("mille", "osas"): ("mille kohta", "kantseliitlik 'osas'; 'kohta' on lihtsam"),
+    ("seoses", "sellega"): ("seetõttu", "kantseliit; 'seetõttu' on lühem"),
+    ("arvestades", "asjaolu"): ("kuna", "kantseliit; alusta kõrvallauset sõnaga 'kuna'"),
+}
+
+# Subordinating conjunctions + relative pronouns whose pile-up inside ONE
+# sentence is what makes Estonian officialese unreadable. Counted per
+# sentence by check_officialese; this is the 'mille käigus … ning …'
+# failure mode that a raw word count misses.
+_SUBORDINATORS_ET: frozenset[str] = frozenset({
+    "et", "kuna", "sest", "kuigi", "mistõttu", "millepärast",
+    "mis", "mida", "mille", "millest", "millega", "millele", "milles",
+    "millist", "milliseid", "kes", "kelle", "keda", "kellele",
+    "kus", "kuhu", "kust", "millal", "kuidas", "nagu",
+})
+
+# Academic / report-register markers. classify_register's original
+# _FORMAL_MARKERS covers legal-administrative vocabulary but scored dense
+# R&D-report officialese as 'neutraalne', score 0.0, zero markers — these
+# fill that hole.
+_ACADEMIC_MARKERS_ET: frozenset[str] = frozenset({
+    "aruandeperiood", "aruandlus", "aruandeperioodil", "ettevõttesiseselt",
+    "valideerima", "verifitseerima", "annoteerima", "kvantifitseerima",
+    "metoodika", "taksonoomia", "hüpotees", "valim", "andmestik",
+    "näitaja", "kriteerium", "indikaator", "parameeter", "protseduur",
+    "analüüsima", "hindama", "mõõtma", "fikseerima", "dokumenteerima",
+    "vastavus", "kooskõla", "lahknevus", "järeldus", "tulemus",
+    "eesmärgipärane", "süstemaatiline", "märkimisväärne", "vastavalt",
+    "arvestades", "tulenevalt", "olemasolev", "asjaomane",
+})
+
+# Below this word count classify_register scores on the lexicon alone —
+# impersonal-voice and noun-density ratios are too noisy on a sentence or
+# two to move a register verdict.
+_REGISTER_STRUCTURE_MIN_WORDS = 25
+
 # Specialised Estonian legal terms of art. Used to (1) protect them from
 # over-eager simplification, (2) suppress compound-familiarity false
 # 'coinage' flags on legal compounds, (3) mark legal register. STARTER SET.
@@ -658,6 +745,124 @@ def _first(values: list[Any] | None) -> Any:
     if not values:
         return None
     return values[0]
+
+
+# Olema-forms (plus the negative 'pole' family) that turn a following -tud
+# participle into an impersonal predicate rather than a modifier:
+# 'on kasutatud andmeid' (impersonal) vs 'lukustatud hindamisosa'
+# (attributive). Used by _impersonal_voice.
+_OLEMA_FORMS_ET: frozenset[str] = frozenset({
+    "on", "oli", "olid", "olen", "oled", "oleme", "olete", "olnud",
+    "ole", "olema", "oleks", "olevat", "pole", "polnud", "polegi",
+})
+
+# Impersonal present NEGATIVE form codes ('ei esitata', 'ei kasutata').
+# Kept separate from _PASSIVE_FORMS_ET because bare 'da' is also the
+# da-infinitive code — these only count when a negation precedes.
+_IMPERSONAL_NEG_FORMS_ET: frozenset[str] = frozenset({"ta", "da"})
+
+# VERBAL negation only — the subset of _NEGATION_LEMMAS_ET that actually
+# turns a following participle into a predicate. `mitte` negates a noun
+# phrase, not a verb ('mitte inimeste antud märgenditega'), and `ära` /
+# `ärge` negate imperatives, which are personal forms; including either
+# here would over-count impersonals.
+_VERBAL_NEGATION_ET: frozenset[str] = frozenset({"ei", "pole", "polnud"})
+
+
+def _span_bits(span) -> tuple[str, str, str]:
+    """(pos, form, lemma) for a morph_analysis span, lower-cased, never None."""
+    return (
+        (_first(list(span.partofspeech)) or ""),
+        (_first(list(span.form)) or ""),
+        (_first(list(span.lemma)) or "").lower(),
+    )
+
+
+def _impersonal_voice(spans: list) -> dict:
+    """Count Estonian umbisikuline tegumood ('passive') over a span list.
+
+    Vabamorf's raw form codes alone produce a wrong ratio in four ways,
+    every one of which showed up on real Estonian report prose:
+
+    1. `ei` / `ära` are tagged `pos=V form=neg`, so each negation inflated
+       `total_verbs` and DEFLATED the impersonal ratio. Now excluded.
+    2. `ta`/`da` (impersonal present negative — `ei esitata`) is a form
+       code the -takse/-ti/-tud/-tav set never covered, so negated
+       impersonals were missed outright. Now counted, but only after a
+       negation, because bare `da` is also the da-infinitive.
+    3. `ei avaldatud` is tagged `pos=A` (adjective), not V, so it was
+       skipped entirely. Now counted when a negation precedes.
+    4. `Lukustatud hindamisosas` is a participle used as a MODIFIER, not
+       an impersonal predicate, and was counted as passive. A -tud
+       participle now counts only when an olema-form or a negation sits
+       within the two preceding tokens; otherwise it lands in
+       `attributive_excluded` instead of inflating the ratio.
+
+    Pure function over spans (no model I/O) so it is unit-testable and can
+    be shared by check_style, check_officialese and classify_register.
+    """
+    impersonal = 0
+    verbs = 0
+    examples: list[str] = []
+    attributive_excluded: list[str] = []
+
+    def _preceded_by(i: int, lemmas: frozenset[str], window: int = 2) -> bool:
+        for j in range(max(0, i - window), i):
+            if _span_bits(spans[j])[2] in lemmas:
+                return True
+        return False
+
+    for i, span in enumerate(spans):
+        pos, form, lemma = _span_bits(span)
+
+        # (3) negated impersonal participle mis-tagged as an adjective.
+        if pos == "A" and (lemma.endswith("tud") or lemma.endswith("dud")):
+            if _preceded_by(i, _VERBAL_NEGATION_ET):
+                verbs += 1
+                impersonal += 1
+                if len(examples) < 5 and span.text not in examples:
+                    examples.append(span.text)
+            continue
+
+        if pos != "V":
+            continue
+
+        # (1) `ei` / `ära` are auxiliaries, not verbs worth counting.
+        if lemma in _NEGATION_LEMMAS_ET or form == "neg":
+            continue
+
+        verbs += 1
+
+        # (4) -tud participle: impersonal predicate only with olema/negation.
+        if form in ("tud", "dud"):
+            if _preceded_by(i, _OLEMA_FORMS_ET) or _preceded_by(i, _VERBAL_NEGATION_ET):
+                impersonal += 1
+                if len(examples) < 5 and span.text not in examples:
+                    examples.append(span.text)
+            elif len(attributive_excluded) < 5 and span.text not in attributive_excluded:
+                attributive_excluded.append(span.text)
+            continue
+
+        # (2) impersonal present negative — only after a negation.
+        if form in _IMPERSONAL_NEG_FORMS_ET:
+            if _preceded_by(i, _VERBAL_NEGATION_ET):
+                impersonal += 1
+                if len(examples) < 5 and span.text not in examples:
+                    examples.append(span.text)
+            continue
+
+        if form in _PASSIVE_FORMS_ET:
+            impersonal += 1
+            if len(examples) < 5 and span.text not in examples:
+                examples.append(span.text)
+
+    return {
+        "passive_count": impersonal,
+        "total_verbs": verbs,
+        "ratio": round((impersonal / verbs) if verbs else 0.0, 3),
+        "examples": examples,
+        "attributive_excluded": attributive_excluded,
+    }
 
 
 # Per-tool invocation counters. Incremented only when a tool function
@@ -751,6 +956,7 @@ class _RegisterResult(TypedDict, total=False):
     formal_markers: list[str]
     colloquial_markers: list[str]
     consistency: dict
+    structure: dict
     word_count: int
     note: str
 
@@ -1261,6 +1467,18 @@ def synonyms(word: Annotated[str, Field(description="A single Estonian word to l
     verb in marketing copy. Word-sense ambiguity is preserved: a polysemous
     word returns multiple synsets, one per meaning. Input capped at 200
     characters.
+
+    WORD-FIT CHECK: when the question is "is this the right word here?"
+    rather than "give me an alternative", READ EACH `definition` and test
+    it against the user's actual context — do not just harvest `lemmas`.
+    Estonian glosses routinely carry a domain constraint that decides the
+    answer: `korpus` returns the sense "kirjaliku või suulise teksti
+    elektrooniline kogu", so calling a set of IMAGES a `korpus` is wrong
+    however natural it sounds in ML jargon; `andmestik` carries no such
+    constraint. A gloss naming a medium, field, or material is a
+    constraint on where the word may be used. Note also that a word can
+    be well-formed, correctly spelled and still the wrong register — for
+    that, check_officialese and classify_register, not this tool.
     """
     _check_text(word, limit=MAX_WORD_CHARS, name="word")
     if any(ch.isspace() for ch in word):
@@ -1286,23 +1504,27 @@ def _classify_register(text: str) -> dict:
     t = Text(text)
     t.tag_layer(["morph_analysis"])
 
+    spans = list(t.morph_analysis)
     formal_hits: list[str] = []
     colloquial_hits: list[str] = []
     word_count = 0
+    noun_count = 0
 
-    for span in t.morph_analysis:
+    for span in spans:
         word = span.text
         # Skip punctuation
         if not any(ch.isalpha() for ch in word):
             continue
         word_count += 1
+        if _first(list(span.partofspeech)) == "S":
+            noun_count += 1
         # Test against both surface form and best lemma; lower-cased.
         lemma = (list(span.lemma)[0] if span.lemma else "").lower()
         surface = word.lower()
         for candidate in {surface, lemma}:
             if not candidate:
                 continue
-            if candidate in _FORMAL_MARKERS:
+            if candidate in _FORMAL_MARKERS or candidate in _ACADEMIC_MARKERS_ET:
                 formal_hits.append(candidate)
                 break
             if candidate in _COLLOQUIAL_MARKERS:
@@ -1313,9 +1535,37 @@ def _classify_register(text: str) -> dict:
     # Normalise by word count so longer text doesn't dominate.
     if word_count == 0:
         score = 0.0
+        raw = 0
     else:
         raw = len(formal_hits) - len(colloquial_hits)
         score = max(-1.0, min(1.0, raw * 4.0 / word_count))
+
+    # Structural signals. The tool's own note always conceded that real
+    # register lives in syntax as much as vocabulary — and a dense R&D
+    # report scored 'neutraalne', 0.0, with zero markers, while 87.5% of
+    # its verbs were umbisikuline tegumood. Impersonal voice and noun
+    # density now contribute, bounded and additive-only:
+    #   * they apply only from 25 words up, so short strings still score
+    #     purely on the lexicon;
+    #   * they apply only when the lexicon is not net-colloquial, so
+    #     chatty copy can never be nudged formal.
+    imp = _impersonal_voice(spans)
+    noun_verb_ratio = (
+        noun_count / imp["total_verbs"] if imp["total_verbs"] else 0.0
+    )
+    structural_signals: list[str] = []
+    structural = 0.0
+    if word_count >= _REGISTER_STRUCTURE_MIN_WORDS and raw >= 0:
+        if imp["ratio"] >= 0.4:
+            structural += 0.15
+            structural_signals.append("umbisikuline tegumood")
+        if imp["ratio"] >= 0.7:
+            structural += 0.10
+        if noun_verb_ratio >= _OFFICIALESE_NOUN_VERB_RATIO:
+            structural += 0.15
+            structural_signals.append("nimisõnade kuhjumine")
+        structural = min(structural, 0.4)
+        score = max(-1.0, min(1.0, score + structural))
 
     if score >= 0.25:
         tier = "formal"
@@ -1371,15 +1621,33 @@ def _classify_register(text: str) -> dict:
             "is_mixed": is_mixed,
             "summary_estonian": consistency_et,
         },
+        "structure": {
+            "impersonal_ratio": imp["ratio"],
+            "noun_verb_ratio": round(noun_verb_ratio, 2),
+            "signals": structural_signals,
+            "applied": round(structural, 3),
+            "summary_estonian": (
+                f"Lauseehitus viitab ametlikule stiilile: "
+                f"{', '.join(structural_signals)}."
+                if structural_signals
+                else "Lauseehitus ametlikule stiilile ei viita."
+            ),
+        },
         "word_count": word_count,
         "note": (
-            "Heuristic phase-1 classifier — lexicon-based, lemma-aware. "
-            "Catches obvious officialese vs slang; most newsletter prose "
-            "scores 'neutral'. The `consistency` field flags texts that "
-            "carry BOTH formal AND colloquial markers — useful for "
+            "Heuristic classifier — lexicon-based and lemma-aware, plus "
+            "two structural signals. The lexicon covers legal-"
+            "administrative AND academic/report vocabulary. `structure` "
+            "adds umbisikuline tegumood ratio and noun/verb density, "
+            "bounded at +0.4 and applied only from 25 words up and only "
+            "when the lexicon is not net-colloquial — without them a dense "
+            "R&D report scored 'neutraalne' at 0.0 while 87.5% of its "
+            "verbs were impersonal. The `consistency` field flags texts "
+            "that carry BOTH formal AND colloquial markers — useful for "
             "catching jarring register-mixing even when the overall "
             "tier rounds to 'neutral'. Treat as a directional hint, not "
-            "a verdict. When composing an Estonian-language reply, "
+            "a verdict; for a full kantseliit breakdown use "
+            "check_officialese. When composing an Estonian-language reply, "
             "USE THE tier_estonian AND consistency.summary_estonian "
             "FIELDS VERBATIM rather than translating yourself — common "
             "mistranslations include 'formalne' (wrong) vs 'formaalne' "
@@ -1906,7 +2174,8 @@ def _familiarity_verdict(
     in-vocab → never suspect (the word is among the 100K most frequent,
     i.e. attested). Out-of-vocab → suspect when the top neighbour score is
     weak OR the neighbours are dominated by scrape-artifact tokens (the
-    mõtteliin failure mode, 4/5 junk). Subword-echo overlap is COUNTED and
+    mõtteliin failure mode, 4/5 junk) AND that junky tail is decisive —
+    see the comment on `tail_is_decisive`. Subword-echo overlap is COUNTED and
     surfaced but never triggers on its own: real sibling compounds share a
     head morpheme too (tervisekindlustus ↔ ravikindlustus), so echoes
     don't discriminate coinages from rare-but-real compounds."""
@@ -1928,7 +2197,18 @@ def _familiarity_verdict(
             f"out-of-vocabulary with weak top similarity "
             f"({top_score:.3f} < {_FAMILIARITY_SUSPECT_SCORE})"
         )
-    if n and (junk / n) >= _FAMILIARITY_JUNK_RATIO:
+    # The junk-tail gate is only DECISIVE when the compound is also weak at
+    # the top, or its nearest neighbour is itself junk. A clean, real,
+    # >= 0.60 top neighbour vouches for the compound whatever the tail looks
+    # like: a junky tail then describes how sparse that corner of the
+    # 100K-vocab model is, not whether the word is real. Without this guard
+    # the gate inverted human judgement on ordinary compounds —
+    # `pildiandmestik` (top neighbour `andmestik`, 0.71) was flagged while
+    # `teadusandmestik` (0.705) passed. mõtteliin still flags: its top
+    # neighbour scores 0.536, under the gate.
+    top_is_junk = bool(names) and _looks_like_scrape_junk(names[0])
+    tail_is_decisive = top_score < _FAMILIARITY_SUSPECT_SCORE or top_is_junk
+    if n and (junk / n) >= _FAMILIARITY_JUNK_RATIO and tail_is_decisive:
         reasons.append(
             f"{junk}/{n} nearest neighbours are scrape-artifact tokens, "
             "not real Estonian words"
@@ -2044,11 +2324,20 @@ def _check_compound_familiarity(text: str) -> dict:
             "compounds are treated as real Estonian and never flagged. An "
             "out-of-vocab compound is flagged as suspect when EITHER its "
             "top neighbour similarity is below 0.60 OR at least 40% of its "
-            "neighbours are scrape-artifact tokens (per-entry `reasons` "
-            "says which). The 0.60 gate catches coinages like "
-            "'toortõlkeoht' (top 0.571) that the older 0.55 gate missed; "
-            "the junk-neighbour gate catches calques like 'mõtteliin' "
-            "whose neighbours are mostly web-scrape junk. `neighbour_"
+            "neighbours are scrape-artifact tokens AND that junky tail is "
+            "decisive — i.e. the top score is also under 0.60, or the top "
+            "neighbour is itself junk (per-entry `reasons` says which). The "
+            "0.60 gate catches coinages like 'toortõlkeoht' (top 0.571) "
+            "that the older 0.55 gate missed; the junk-neighbour gate "
+            "catches calques like 'mõtteliin' whose neighbours are mostly "
+            "web-scrape junk. The decisiveness guard stops ordinary "
+            "compounds whose nearest neighbour is a real word (e.g. "
+            "'pildiandmestik' → 'andmestik', 0.71) from being flagged just "
+            "because that corner of the vocabulary is sparse. NOTE the "
+            "converse limit: a well-formed compound that is merely STILTED "
+            "rather than invented ('teadusandmestik', 0.705) will pass — "
+            "similarity cannot judge register or idiom, so use "
+            "check_officialese and classify_register for that. `neighbour_"
             "quality` reports the neighbour, scrape_junk and subword_echo "
             "counts. NOT authoritative — even at 100K vocab some legitimate "
             "but rare compounds are OOV; the rule favours recall (a flagged "
@@ -2871,21 +3160,14 @@ def _check_style(text: str) -> dict:
             "positions": lemma_positions[lemma],
         })
 
-    # 2. Passive voice — count verbs whose form is in the passive set.
-    passive_count = 0
-    passive_examples: list[str] = []
-    verb_count = 0
-    for span in spans:
-        pos = _first(list(span.partofspeech))
-        if pos != "V":
-            continue
-        verb_count += 1
-        form = _first(list(span.form))
-        if form and form in _PASSIVE_FORMS_ET:
-            passive_count += 1
-            if len(passive_examples) < 5 and span.text not in passive_examples:
-                passive_examples.append(span.text)
-    passive_ratio = (passive_count / verb_count) if verb_count else 0.0
+    # 2. Umbisikuline tegumood — see _impersonal_voice for the four
+    # counting corrections over raw Vabamorf form codes.
+    imp = _impersonal_voice(spans)
+    passive_count = imp["passive_count"]
+    verb_count = imp["total_verbs"]
+    passive_ratio = imp["ratio"]
+    passive_examples = imp["examples"]
+    attributive_excluded = imp["attributive_excluded"]
 
     # 3. Sentence-length variance (in content words per sentence).
     sentence_lengths: list[int] = []
@@ -2953,6 +3235,7 @@ def _check_style(text: str) -> dict:
             "total_verbs": verb_count,
             "ratio": round(passive_ratio, 3),
             "examples": passive_examples,
+            "attributive_excluded": attributive_excluded,
             "summary_estonian": passive_et,
         },
         "sentence_length": {
@@ -2972,9 +3255,16 @@ def _check_style(text: str) -> dict:
         },
         "note": (
             "Heuristic phase-1 style checker. Repetition threshold "
-            "scales with text length. Passive-voice ratio uses Vabamorf "
-            "form codes (-takse/-ti/-tud/-tav family); ~15% is a healthy "
-            "ceiling for marketing copy, <5% may read too forceful. "
+            "scales with text length. `passive_voice` counts Estonian "
+            "umbisikuline tegumood: the -takse/-ti/-tud/-tav family, PLUS "
+            "negated impersonals ('ei esitata', 'ei avaldatud') that raw "
+            "Vabamorf form codes miss, MINUS `ei`/`ära` (tagged pos=V but "
+            "not real verbs) and MINUS attributive -tud participles "
+            "('lukustatud osa'), which are listed under "
+            "`attributive_excluded` instead. ~15% is a healthy ceiling for "
+            "marketing copy and <5% may read too forceful; for reports and "
+            "academic prose anything above ~40% is the single clearest "
+            "kantseliit signal — pair this with check_officialese. "
             "Hedging density >5% reads wishy-washy. Sentence length "
             "stddev should typically be at least 30% of the mean for "
             "natural rhythm. Quote *_estonian fields verbatim in "
@@ -3013,6 +3303,526 @@ def check_style(text: Annotated[str, Field(description="Estonian text to compute
     return _check_style(text)
 
 
+# Officialese thresholds, calibrated on a real Estonian R&D report
+# against the plain-language rewrite a native speaker produced from it.
+# Measured across that edit:
+#
+#   impersonal ratio   0.875 → 0.308   (gate 0.4  — separates cleanly)
+#   -mine per 100 wds  7.89  → 2.33    (gate 4.0  — separates cleanly)
+#   longest sentence   30    → 21 wds  (gate 25   — separates cleanly)
+#   noun/verb ratio    2.50  → 2.23    (gate 2.5  — barely separates)
+#
+# Noun/verb is deliberately the loosest gate: one document pair is thin
+# calibration and the two texts sit close together on it, so it is
+# reported as a metric always and raised as an issue only when clearly
+# heavy. The other three carry the signal.
+_OFFICIALESE_LONG_SENTENCE_WORDS = 25
+_OFFICIALESE_CLAUSE_STACK = 3
+_OFFICIALESE_NOUN_VERB_RATIO = 2.5
+_OFFICIALESE_NOMINALISATION_PER_100 = 4.0
+_OFFICIALESE_IMPERSONAL_RATIO = 0.4
+
+
+def _check_officialese(text: str) -> dict:
+    """Kantseliit diagnostic for NON-legal Estonian: reports, academic
+    prose, R&D/grant paperwork, business writing.
+
+    check_legalese exists but is scoped to statutes — on a real Estonian
+    R&D report paragraph it returned zero issues, because its filler
+    lexicon is legal-specific and its length gate (34 words) sits above
+    where Estonian prose actually becomes unreadable. This tool measures
+    what makes such text heavy:
+
+    - nominalisation (-mine verbal nouns) and overall noun/verb density,
+      the classic 'nimisõnastiil'
+    - umbisikuline tegumood, correctly counted (see _impersonal_voice)
+    - clause stacking per sentence — the 'mille käigus … ning …' pile-up
+      a raw word count misses
+    - long sentences, on an Estonian-calibrated gate
+    - administrative filler with plain equivalents
+
+    Precision-first, like its legal sibling: absence of flags is not proof
+    the text is plain.
+    """
+    _check_text(text)
+    Text = _Text()
+    t = Text(text)
+    t.tag_layer(["sentences", "morph_analysis"])
+    spans = list(t.morph_analysis)
+
+    issues: list[dict] = []
+
+    # --- 1. Nominalisation: -mine verbal nouns, with the verb to swap in.
+    nominalisations: list[dict] = []
+    for span in spans:
+        pos, _form, lemma = _span_bits(span)
+        if pos != "S" or not lemma.endswith("mine") or len(lemma) < 7:
+            continue
+        verb = lemma[:-4] + "ma"
+        nominalisations.append({
+            "word": span.text,
+            "lemma": lemma,
+            "position": span.start,
+            "verb": verb,
+        })
+
+    word_count = sum(1 for s in spans if s.text and s.text[0].isalpha())
+    noun_count = sum(1 for s in spans if _span_bits(s)[0] == "S")
+    imp = _impersonal_voice(spans)
+    verb_count = imp["total_verbs"]
+    noun_verb_ratio = (noun_count / verb_count) if verb_count else 0.0
+    nom_per_100 = (len(nominalisations) * 100 / word_count) if word_count else 0.0
+
+    if nom_per_100 >= _OFFICIALESE_NOMINALISATION_PER_100:
+        issues.append({
+            "position": nominalisations[0]["position"] if nominalisations else 0,
+            "rule": "nominalisation",
+            "rule_estonian": "nimisõnastumine (mine-vormide rohkus)",
+            "explanation": (
+                f"Tekstis on {len(nominalisations)} mine-tuletist "
+                f"{word_count} sõna kohta. Tegevust väljendav nimisõna "
+                f"muudab lause raskeks — kasuta tegusõna."
+            ),
+            "suggestion": ", ".join(
+                f"{n['lemma']} → {n['verb']}" for n in nominalisations[:5]
+            ),
+        })
+
+    if noun_verb_ratio >= _OFFICIALESE_NOUN_VERB_RATIO:
+        issues.append({
+            "position": 0,
+            "rule": "noun-density",
+            "rule_estonian": "nimisõnade kuhjumine",
+            "explanation": (
+                f"Nimisõnu on {noun_count}, tegusõnu {verb_count} "
+                f"(suhe {noun_verb_ratio:.2f}). Kui suhe ületab "
+                f"{_OFFICIALESE_NOUN_VERB_RATIO}, loeb tekst end raskelt."
+            ),
+            "suggestion": "muuda osa nimisõnu tegusõnadeks",
+        })
+
+    if imp["ratio"] >= _OFFICIALESE_IMPERSONAL_RATIO and verb_count >= 4:
+        issues.append({
+            "position": 0,
+            "rule": "impersonal-voice",
+            "rule_estonian": "umbisikuline tegumood",
+            "explanation": (
+                f"Umbisikulises tegumoes on {imp['passive_count']}/"
+                f"{verb_count} tegusõna "
+                f"({round(imp['ratio'] * 100, 1)}%). Aruandekeeles on see "
+                f"kõige selgem kantseliidi tunnus — nimeta tegija."
+            ),
+            "suggestion": "kirjuta isikulises tegumoes, nt 'koguti' → 'kogusime'",
+        })
+
+    # --- 2. Per-sentence: clause stacking and length.
+    for sent in t.sentences:
+        s_spans = [s for s in spans if s.start >= sent.start and s.end <= sent.end]
+        n_words = sum(1 for s in s_spans if s.text and s.text[0].isalpha())
+        subs = [s.text for s in s_spans if s.text.lower() in _SUBORDINATORS_ET]
+        preview = sent.enclosing_text
+        preview = (preview[:60] + "…") if len(preview) > 60 else preview
+
+        if len(subs) >= _OFFICIALESE_CLAUSE_STACK:
+            issues.append({
+                "phrase": preview,
+                "position": sent.start,
+                "rule": "clause-stacking",
+                "rule_estonian": "kõrvallausete kuhjumine",
+                "explanation": (
+                    f"Lauses on {len(subs)} kõrvallause algust "
+                    f"({', '.join(subs)}). Jaga lause mitmeks."
+                ),
+                "suggestion": "jaga lause lühemateks lauseteks",
+            })
+        elif n_words >= _OFFICIALESE_LONG_SENTENCE_WORDS:
+            issues.append({
+                "phrase": preview,
+                "position": sent.start,
+                "rule": "long-sentence",
+                "rule_estonian": "liiga pikk lause",
+                "explanation": (
+                    f"Lauses on {n_words} sisusõna (piir "
+                    f"{_OFFICIALESE_LONG_SENTENCE_WORDS}). Eesti keeles "
+                    f"mahub käändevormide tõttu ühte lausesse rohkem infot "
+                    f"kui inglise keeles, nii et pikk lause muutub kiiresti "
+                    f"raskeks."
+                ),
+                "suggestion": "jaga lause lühemateks lauseteks",
+            })
+
+    # --- 3. Administrative filler (lemma-exact + fixed phrase pairs).
+    for i, span in enumerate(spans):
+        pos, _form, lemma = _span_bits(span)
+        low = span.text.lower()
+
+        filler = _OFFICIALESE_LEMMAS_ET.get(lemma) or _OFFICIALESE_SURFACE_ET.get(low)
+        if filler:
+            plain, why = filler
+            issues.append({
+                "word": span.text,
+                "position": span.start,
+                "rule": "officialese-filler",
+                "rule_estonian": "kantseliitlik täitesõna",
+                "explanation": why,
+                "suggestion": plain,
+            })
+
+        if i + 1 < len(spans):
+            pair = (low, spans[i + 1].text.lower())
+            if pair in _OFFICIALESE_PHRASES_ET:
+                plain, why = _OFFICIALESE_PHRASES_ET[pair]
+                issues.append({
+                    "phrase": f"{span.text} {spans[i + 1].text}",
+                    "position": span.start,
+                    "rule": "officialese-phrase",
+                    "rule_estonian": "kantseliitlik väljend",
+                    "explanation": why,
+                    "suggestion": plain,
+                })
+
+        # 'X-i poolt tehtud' — the passive-agent calque. Only when a
+        # genitive noun precedes, so 'hääletas poolt' (in favour) is safe.
+        if low == "poolt" and i > 0:
+            prev_pos, prev_form, _prev_lemma = _span_bits(spans[i - 1])
+            if prev_pos == "S" and prev_form in ("sg g", "pl g"):
+                issues.append({
+                    "phrase": f"{spans[i - 1].text} poolt",
+                    "position": spans[i - 1].start,
+                    "rule": "poolt-calque",
+                    "rule_estonian": "'poolt'-tarind",
+                    "explanation": (
+                        "'X-i poolt tehtud' on tõlkelaen. Eesti keeles "
+                        "piisab omastavast: 'mudeli loodud', mitte "
+                        "'mudeli poolt loodud'."
+                    ),
+                    "suggestion": f"{spans[i - 1].text} (ilma sõnata 'poolt')",
+                })
+
+    issues.sort(key=lambda d: d.get("position", 0))
+
+    return {
+        "text": text,
+        "issues": issues,
+        "metrics": {
+            "word_count": word_count,
+            "noun_count": noun_count,
+            "verb_count": verb_count,
+            "noun_verb_ratio": round(noun_verb_ratio, 2),
+            "nominalisations": nominalisations,
+            "nominalisations_per_100_words": round(nom_per_100, 2),
+            "impersonal_voice": imp,
+        },
+        "summary_estonian": (
+            f"Leiti {len(issues)} kantseliidikohta. Nimisõnade ja tegusõnade "
+            f"suhe on {noun_verb_ratio:.2f}, umbisikulises tegumoes "
+            f"{round(imp['ratio'] * 100, 1)}% tegusõnadest."
+            if issues else
+            "Selget kantseliiti ei tuvastatud."
+        ),
+        "note": (
+            "Heuristic kantseliit diagnostic for NON-legal Estonian "
+            "(reports, academic prose, business writing) — the sibling of "
+            "check_legalese, which is scoped to statutes and stays silent "
+            "on report officialese. Thresholds are calibrated against a "
+            "native speaker's plain-language rewrite of a real Estonian R&D "
+            "report. Across that edit the impersonal ratio went 0.875 → "
+            "0.308, -mine nouns per 100 words 7.89 → 2.33 and the longest "
+            "sentence 30 → 21 content words, so those three gates (0.4, "
+            "4.0, 25) separate bureaucratic from plain cleanly. Noun/verb "
+            "moved only 2.50 → 2.23, so its gate (2.5) is deliberately "
+            "loose and that signal is the weakest of the four — weigh it "
+            "last. `metrics.nominalisations` gives each "
+            "-mine noun with the verb to swap in. STARTER lexicons, "
+            "precision-first and not exhaustive — absence of flags is not "
+            "proof the text is plain. For legal text use check_legalese "
+            "instead: it protects terms of art, which this tool does not. "
+            "Quote rule_estonian and summary_estonian verbatim in Estonian "
+            "replies."
+        ),
+    }
+
+
+class _OfficialeseResult(TypedDict, total=False):
+    """Output of check_officialese: kantseliit issues + density metrics."""
+    text: str
+    issues: list[dict]
+    metrics: dict
+    summary_estonian: str
+    note: str
+
+
+@mcp.tool(annotations=ToolAnnotations(
+    title="Check Estonian officialese (kantseliit in non-legal prose)",
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+@_counted
+def check_officialese(text: Annotated[str, Field(description="Estonian non-legal text (report, academic, business) to check for kantseliit / bureaucratic density.")]) -> _OfficialeseResult:
+    """Flag Estonian kantseliit in reports, academic and business prose.
+
+    check_legalese is the legal-text sibling; use THIS one for anything
+    that is not a statute or contract, where check_legalese finds nothing
+    because its lexicon and length gate are tuned for legislation.
+
+    Returns `issues` (each with an Estonian `rule_estonian` label, an
+    explanation and a concrete suggestion) plus `metrics`:
+
+    - nominalisation: -mine verbal nouns per 100 words, each paired with
+      the verb to use instead (`hindamine` → `hindama`)
+    - noun_verb_ratio: nimisõnastiil density; over ~2.0 reads heavy
+    - impersonal_voice: umbisikuline tegumood, correctly counted
+      (negated impersonals included, `ei`/`ära` and attributive -tud
+      participles excluded)
+    - clause-stacking: 3+ subordinate-clause openers in one sentence, the
+      'mille käigus … ning …' pile-up that a word count alone misses
+    - long-sentence: 25+ content words, calibrated for Estonian
+    - officialese filler: `omama` → `olema`, `kujutab endast` → `on`,
+      `viidi läbi` → `tehti`, `X-i poolt tehtud` → `X-i tehtud`
+
+    Heuristic and precision-first — no flags does not prove the text is
+    plain. Input capped at 100,000 characters.
+    """
+    return _check_officialese(text)
+
+
+# How many distinct content nouns get a WordNet lookup in
+# check_term_consistency. Bounds cost on long documents; the nouns are
+# ranked by frequency first, so the cap drops only long-tail hapaxes.
+_TERM_CONSISTENCY_WORDNET_CAP = 40
+
+
+def _check_term_consistency(text: str) -> dict:
+    """One referent, one term — flag a document that names the same thing
+    several ways.
+
+    This is the failure mode a human editor catches instantly and a model
+    sliding through a long document does not: a dataset called `andmestik`
+    in one paragraph, `teadusandmestik` in the next and `korpus` in a
+    third. Two rules, both precision-first:
+
+    A. Shared compound head. The text uses a bare noun X *and* a compound
+       ending in X (`andmestik` + `teadusandmestik`), or three or more
+       distinct lemmas share one head. Two compounds sharing a head is NOT
+       enough on its own — `tegevusvaldkond` and `märgendusvaldkond` are
+       usually genuinely different things.
+    B. Shared WordNet synset. Two distinct lemmas in the text sit in the
+       same synset, i.e. Estonian WordNet considers them synonyms
+       (`andmestik` / `andmebaas`).
+
+    Reports counts per variant so the caller can pick the dominant term,
+    and never decides which variant is right — that needs context the tool
+    does not have.
+
+    Capped at MAX_TEXT_CHARS, NOT MAX_DOC_CHARS. check_defined_terms may
+    take 500k because it is pure regex; this one runs full morphological
+    analysis over the whole document, which is ~4s per 100k chars. At 500k
+    a single call would burn ~22s of CPU, which would blow the
+    defence-in-depth budget the public per-IP rate limit is sized against.
+    """
+    _check_text(text, limit=MAX_TEXT_CHARS)
+    Text = _Text()
+    t = Text(text)
+    t.tag_layer(["morph_analysis"])
+
+    from collections import Counter, defaultdict
+
+    counts: Counter = Counter()
+    first_pos: dict[str, int] = {}
+    heads: dict[str, str] = {}
+
+    for span in t.morph_analysis:
+        pos = _first(list(span.partofspeech))
+        if pos != "S":
+            continue
+        lemma_raw = _first(list(span.lemma)) or ""
+        if not lemma_raw or lemma_raw[0].isupper() or len(lemma_raw) < 4:
+            continue
+        lemma = lemma_raw.lower()
+        rt_lists = [list(rt) for rt in span.root_tokens]
+        parts = rt_lists[0] if rt_lists else []
+        counts[lemma] += 1
+        first_pos.setdefault(lemma, span.start)
+        heads[lemma] = (parts[-1].lower() if parts else lemma)
+
+    groups: list[dict] = []
+    grouped_lemmas: set[str] = set()
+
+    # --- Rule A: shared compound head.
+    by_head: dict[str, set[str]] = defaultdict(set)
+    for lemma, head in heads.items():
+        by_head[head].add(lemma)
+
+    for head, lemmas in sorted(by_head.items()):
+        if len(lemmas) < 2:
+            continue
+        bare_present = head in lemmas
+        if not (bare_present or len(lemmas) >= 3):
+            continue
+        variants = sorted(lemmas, key=lambda w: (-counts[w], w))
+        groups.append({
+            "head": head,
+            "rule": "shared-compound-head",
+            "rule_estonian": "sama põhisõna",
+            "variants": [
+                {"lemma": w, "count": counts[w], "position": first_pos[w]}
+                for w in variants
+            ],
+            "dominant": variants[0],
+            "explanation": (
+                f"Tekstis kasutatakse sama põhisõnaga termineid: "
+                f"{', '.join(variants)}. Kui need tähistavad üht ja sama "
+                f"asja, vali üks ja kasuta seda läbivalt."
+            ),
+        })
+        grouped_lemmas.update(lemmas)
+
+    # --- Rule B: shared WordNet synset.
+    #
+    # WordNet ships pre-downloaded in the server image, so this is a local
+    # lookup with no network access. If the resource is somehow absent,
+    # EstNLTK tries to fetch it and prompts for confirmation — which would
+    # breach the no-outbound-network posture, and, worse, writes that
+    # prompt to STDOUT, which in stdio transport IS the MCP protocol
+    # channel. Redirecting stdout to stderr for the duration keeps the
+    # protocol stream clean whatever EstNLTK decides to print;
+    # BaseException covers the EOFError / SystemExit the prompt raises
+    # when stdin is closed. Rule B then degrades to off and `rules_run`
+    # says so rather than silently returning fewer groups.
+    import contextlib
+
+    ranked = [w for w, _ in counts.most_common(_TERM_CONSISTENCY_WORDNET_CAP)]
+    synsets_by_lemma: dict[str, set[str]] = {}
+    wordnet_ok = True
+    try:
+        with contextlib.redirect_stdout(sys.stderr):
+            wn = _wordnet()
+    except BaseException:
+        wn = None
+        wordnet_ok = False
+    if wn is not None:
+        for lemma in ranked:
+            try:
+                synsets_by_lemma[lemma] = {s.name for s in (wn[lemma] or [])}
+            except BaseException:
+                synsets_by_lemma[lemma] = set()
+                wordnet_ok = False
+
+    seen_pairs: set[tuple[str, str]] = set()
+    for i, a in enumerate(ranked):
+        for b in ranked[i + 1:]:
+            if a == b or (a, b) in seen_pairs:
+                continue
+            shared = synsets_by_lemma.get(a, set()) & synsets_by_lemma.get(b, set())
+            if not shared:
+                continue
+            # Skip pairs Rule A already reported together.
+            if heads.get(a) == heads.get(b) and {a, b} <= grouped_lemmas:
+                continue
+            seen_pairs.add((a, b))
+            variants = sorted([a, b], key=lambda w: (-counts[w], w))
+            groups.append({
+                "head": None,
+                "rule": "shared-wordnet-synset",
+                "rule_estonian": "sama tähendusrühm",
+                "synsets": sorted(shared),
+                "variants": [
+                    {"lemma": w, "count": counts[w], "position": first_pos[w]}
+                    for w in variants
+                ],
+                "dominant": variants[0],
+                "explanation": (
+                    f"'{a}' ja '{b}' kuuluvad eesti WordNetis samasse "
+                    f"tähendusrühma ({', '.join(sorted(shared))}). Kui need "
+                    f"tähistavad üht ja sama asja, vali üks."
+                ),
+            })
+
+    groups.sort(key=lambda g: g["variants"][0]["position"])
+
+    return {
+        "text": text,
+        "groups": groups,
+        "terms_analysed": len(counts),
+        "rules_run": {
+            "shared-compound-head": True,
+            "shared-wordnet-synset": wordnet_ok,
+        },
+        "summary_estonian": (
+            f"Leiti {len(groups)} rühma, kus üht asja võidakse nimetada "
+            f"mitmel viisil. Vali igas rühmas üks termin ja kasuta seda "
+            f"läbivalt."
+            if groups else
+            "Ebajärjekindlat terminikasutust ei tuvastatud."
+        ),
+        "note": (
+            "Heuristic terminology-consistency check: 'one referent, one "
+            "term'. Rule `shared-compound-head` fires when a bare noun and "
+            "a compound built on it both appear (andmestik + "
+            "teadusandmestik), or when 3+ lemmas share one head; two "
+            "compounds sharing a head is deliberately NOT enough, since "
+            "those are usually distinct things. Rule "
+            "`shared-wordnet-synset` fires when two lemmas sit in the same "
+            "Estonian WordNet synset. The tool does NOT decide which "
+            "variant is correct — that needs domain context it cannot see; "
+            "it reports counts so you can pick the dominant term, and some "
+            "groups are legitimately distinct concepts. KNOWN GAP: "
+            "synonym pairs that share neither a head nor a synset "
+            "(korpus / andmestik) are not caught — for those, read each "
+            "candidate's `synonyms` definition and check whether its "
+            "domain fits the text. WordNet lookups are capped at the "
+            f"{_TERM_CONSISTENCY_WORDNET_CAP} most frequent nouns, and "
+            "`rules_run` reports whether the WordNet rule actually ran — "
+            "if the resource is unavailable it degrades to the "
+            "compound-head rule alone rather than failing. Input "
+            "capped at 100,000 characters."
+        ),
+    }
+
+
+class _TermConsistencyResult(TypedDict, total=False):
+    """Output of check_term_consistency: groups of competing terms."""
+    text: str
+    groups: list[dict]
+    terms_analysed: int
+    rules_run: dict
+    summary_estonian: str
+    note: str
+
+
+@mcp.tool(annotations=ToolAnnotations(
+    title="Check Estonian terminology consistency (one referent, one term)",
+    readOnlyHint=True,
+    idempotentHint=True,
+    openWorldHint=False,
+))
+@_counted
+def check_term_consistency(text: Annotated[str, Field(description="Estonian document to check for the same thing being named several different ways.")]) -> _TermConsistencyResult:
+    """Flag a document that calls the same thing several different names.
+
+    The classic long-document defect, and the one a model editing
+    paragraph-by-paragraph reliably misses: a dataset that is `andmestik`
+    on page 1, `teadusandmestik` on page 2 and `korpus` on page 3.
+
+    Two precision-first rules:
+
+    - `shared-compound-head`: a bare noun and a compound built on it both
+      occur (`andmestik` + `pildiandmestik`), or 3+ lemmas share one head.
+    - `shared-wordnet-synset`: two lemmas sit in one Estonian WordNet
+      synset, i.e. WordNet calls them synonyms.
+
+    Each group lists its variants with occurrence counts and the dominant
+    one, so you can standardise on the most-used term. The tool does not
+    decide which variant is right — some groups are genuinely distinct
+    concepts, so read them before rewriting.
+
+    Known gap: synonyms sharing neither a head nor a synset (korpus /
+    andmestik) are not caught. Input capped at 100,000 characters.
+    """
+    return _check_term_consistency(text)
+
+
 @mcp.tool(annotations=ToolAnnotations(
     title="Classify Estonian register (formal vs colloquial)",
     readOnlyHint=True,
@@ -3033,11 +3843,16 @@ def classify_register(text: Annotated[str, Field(description="Estonian text to c
     hasn't drifted into officialese, or that a contract draft hasn't
     slipped into chat tone.
 
-    PHASE-1 LIMITATION: this is a coarse lexicon-based heuristic, not a
-    trained model. Real register also lives in sentence structure,
-    address forms, and passive voice — none of which this catches. Most
-    newsletter prose scores 'neutral'. Use the result as a directional
-    hint, not a verdict. Input capped at 100,000 characters.
+    The lexicon covers legal-administrative AND academic/report
+    vocabulary. `structure` adds two syntactic signals — umbisikuline
+    tegumood ratio and noun/verb density — bounded at +0.4, applied only
+    from 25 words up and only when the lexicon is not net-colloquial.
+
+    LIMITATION: still a heuristic, not a trained model. Address forms and
+    finer syntax go uncaught, and most newsletter prose scores 'neutral'.
+    Use the result as a directional hint, not a verdict; for a full
+    kantseliit breakdown with per-issue suggestions, call
+    check_officialese. Input capped at 100,000 characters.
     """
     return _classify_register(text)
 

--- a/server.py
+++ b/server.py
@@ -2283,10 +2283,17 @@ def _check_compound_familiarity(text: str) -> dict:
         # solidaarvõlgnik, abieluvaraleping) are OOV in the general-web
         # fastText vocab and were false-flagged as coinages (~15% of legal
         # compounds). A known term of art is real by definition.
-        if is_suspect and _is_legal_term(lemma):
-            is_suspect = False
-            reasons = []
+        #
+        # The marker is stamped for EVERY term of art, not only ones whose
+        # verdict had to be rescued. Since the junk-tail decisiveness guard
+        # landed, a compound like `solidaarvõlgnik` (top neighbour
+        # `võlgnik`, 0.625) is already cleared before this runs — but the
+        # caller still wants to know it is attested legal vocabulary.
+        if _is_legal_term(lemma):
             quality = {**quality, "legal_term": True}
+            if is_suspect:
+                is_suspect = False
+                reasons = []
 
         compounds.append({
             "word": span.text,

--- a/skills/README.md
+++ b/skills/README.md
@@ -13,7 +13,7 @@ just markdown — and can be installed without redeploying anything.
 
 | Skill | What it does |
 | --- | --- |
-| [`estonian-writing-assistant`](estonian-writing-assistant/SKILL.md) | Guides Claude through proofreading, register-aware rewriting, breaking repetition, and morphology study using the ten estonian-mcp tools. Documents tool quirks (Vabamorf misses on neologisms, fastText antonym-near-neighbours, polysemy) and anti-patterns (inventing case forms, bypassing spell_check). |
+| [`estonian-writing-assistant`](estonian-writing-assistant/SKILL.md) | Guides Claude through proofreading, register-aware rewriting, de-bureaucratising Estonian prose, terminology consistency, and morphology study using the estonian-mcp tools. Documents tool quirks (Vabamorf misses on neologisms, fastText antonym-near-neighbours, polysemy) and anti-patterns (inventing case forms, bypassing spell_check). |
 
 ## Adding to the Anthropic Connectors Directory
 

--- a/skills/estonian-writing-assistant/SKILL.md
+++ b/skills/estonian-writing-assistant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: estonian-writing-assistant
-description: "Use this skill whenever the user is writing, editing, proofreading, or studying Estonian text and the estonian-mcp connector is available — even if they don't explicitly ask. Covers proofreading (spell_check first, then verify lemma and case forms via lemmatize and analyze_morphology on uncertain words), tone-aware rewrites (classify_register before and after edits to confirm the register matches the audience), vocabulary diversification (synonyms from WordNet for same-meaning swaps; find_related_words via fastText for adjacent concepts in marketing copy), morphology study, compound splits, syllabification, and named-entity extraction from Estonian news or documents. Core principle — never invent Estonian lemmas, case endings, conjugations, or spellings; always verify with the MCP tools, because models routinely hallucinate Estonian inflections. Documents tool quirks inline (fastText antonym-near-neighbours, polysemy, Vabamorf gaps on neologisms, synonyms-vs-related-words decision rule) and anti-patterns."
+description: "Use this skill whenever the user is writing, editing, proofreading, or studying Estonian text and the estonian-mcp connector is available — even if they don't explicitly ask. Covers proofreading (spell_check first, then verify lemma and case forms via lemmatize and analyze_morphology on uncertain words), tone-aware rewrites (classify_register before and after edits to confirm the register matches the audience), de-bureaucratising stiff Estonian prose (check_officialese for kantseliit in reports, academic and business writing, where check_legalese stays silent), keeping one term per referent across a long document (check_term_consistency), answering 'is this the right word here?' by reading each WordNet gloss's domain constraint rather than trusting ML-jargon familiarity, vocabulary diversification (synonyms from WordNet for same-meaning swaps; find_related_words via fastText for adjacent concepts in marketing copy), morphology study, compound splits, syllabification, and named-entity extraction from Estonian news or documents. Core principle — never invent Estonian lemmas, case endings, conjugations, or spellings; always verify with the MCP tools, because models routinely hallucinate Estonian inflections. Documents tool quirks inline (fastText antonym-near-neighbours, polysemy, Vabamorf gaps on neologisms, synonyms-vs-related-words decision rule) and anti-patterns."
 ---
 
 # Estonian writing assistant
@@ -36,7 +36,9 @@ The hard rule, applied throughout this skill:
 | `check_redundancy` | Pleonasm / semantic-doubling check — flags `samuti ka` (also+also), `kõige optimaalsem` (most+optimal), and fixed redundant phrases. Run it before claiming a redundancy "the MCP can't catch" — it catches the common ones. |
 | `check_object_case` | Käändeõpetus heuristic — catches the most common confidently-wrong Estonian: direct-object case after negation (must be partitive) and after partitive-only verbs (`armastama`, `vihkama`, `vajama`, …). Lexicon-based, no syntactic parser; only flags nouns AFTER the trigger so subject-noun false positives are minimal. |
 | `check_abbreviation_hyphenation` | Lühendiortograafia — flags abbreviations carrying a case ending without the EKI-mandated hyphen (`MCPst` → `MCP-st`, `OÜle` → `OÜ-le`, `APIga` → `API-ga`). Uses Vabamorf's POS+form analysis to filter to actual abbreviations. |
-| `check_compound_familiarity` | Calque-risk diagnostic — surfaces fastText nearest-neighbour data for each compound noun. Suspect flag = top similarity < 0.55. **Critically**, the threshold also flags some legitimate-but-uncommon compounds (small fastText vocab). Read the `neighbours` list to judge: subword-similar neighbours = likely calque; semantically coherent neighbours = real compound. Run on any Estonian compound you yourself produced (rather than verbatim user input) — if flagged, search for a more idiomatic native phrasing before sending. |
+| `check_compound_familiarity` | Calque-risk diagnostic — surfaces fastText nearest-neighbour data for each compound noun. Suspect flag = top similarity < 0.60, or a junk-dominated neighbour tail when that tail is decisive (top score also under 0.60, or the top neighbour is itself junk). **Critically**, it still flags some legitimate-but-uncommon compounds (small fastText vocab). Read the `neighbours` list to judge: subword-similar neighbours = likely calque; semantically coherent neighbours = real compound. Note the converse limit too: a compound that is merely *stilted* rather than invented (`teadusandmestik`) will pass — similarity can't judge register, so use `check_officialese` for that. Run on any Estonian compound you yourself produced (rather than verbatim user input). |
+| `check_officialese` | Kantseliit check for **non-legal** prose — reports, academic writing, business copy, grant/R&D paperwork. Use this, not `check_legalese`, for anything that isn't a statute or contract: `check_legalese`'s lexicon and 34-word gate are tuned for legislation and return nothing on report officialese. Gives nominalisation density with the verb to swap in (`hindamine` → `hindama`), correctly-counted umbisikuline tegumood, clause stacking, Estonian-calibrated sentence length, and admin filler. |
+| `check_term_consistency` | One referent, one term. Run on any document longer than a couple of paragraphs: catches `andmestik` in §1, `teadusandmestik` in §2, `pildiandmestik` in §3. Reports per-variant counts so you can standardise on the dominant one. Read each group before rewriting — some are genuinely distinct concepts. |
 | `check_capitalization` | Algustäheortograafia (initial-letter orthography) check per EKI Reeglid. Flags weekdays, months, nationalities, and language/culture adjectives wrongly capitalized mid-sentence. Run on every Estonian text you produce. |
 | `check_compounds` | Liitsõnaõigekiri — flags common compound splits the model produces (`kooli maja` → `koolimaja`). Lexicon-based, phase 1. |
 | `check_punctuation` | Kirjavahemärgid — flags missing commas before subordinating conjunctions (et, sest, kuna, kuid, vaid, nagu, …). Phase-1 scope: the comma-before-clause rule only. |
@@ -112,10 +114,63 @@ more "on brand":
 5. Call `classify_register` on the rewrite to confirm the shift
    landed.
 
-`classify_register` is a **phase-1 heuristic** — most newsletter
-prose intentionally scores "neutral" because the markers it catches
-are absent. Don't over-interpret a neutral score; it just means
-"no obvious officialese or slang detected."
+`classify_register` is a **heuristic** — most newsletter prose
+intentionally scores "neutral" because the markers it catches are
+absent. Don't over-interpret a neutral score; it just means "no obvious
+officialese or slang detected." Its `structure` block adds umbisikuline
+tegumood ratio and noun density, which is what stops dense report prose
+from scoring neutral, but it only applies from 25 words up.
+
+### 2b. Make bureaucratic Estonian readable
+
+When the user says a text is heavy, stiff, "kantseliitlik", or asks you
+to make it "inimlikum" / simpler to read — and it is **not** a statute
+or contract:
+
+1. Call `check_officialese`. Work the issues in this order, because
+   this is the order in which they change how the text reads:
+   - `impersonal-voice` — name the actor. `koguti` → `kogusime`. This
+     is the single biggest lever in Estonian report prose.
+   - `nominalisation` — each `-mine` noun comes back paired with the
+     verb to use instead. `metoodika väljatöötamine` → `töötati välja
+     metoodika`.
+   - `clause-stacking` / `long-sentence` — split. Prefer chronological
+     order: first what was done, then what came of it.
+   - `officialese-filler` / `officialese-phrase` / `poolt-calque` —
+     straight swaps, each with a suggestion.
+2. Call `check_term_consistency` on the whole document and pick one
+   term per group. Do this **before** rewriting, so the rewrite
+   standardises rather than adding a fourth variant.
+3. Re-run `check_officialese` on your rewrite. The metrics should move:
+   impersonal ratio down, `-mine` per 100 words down, longest sentence
+   down.
+
+Hard rule for this workflow: **every number, percentage and factual
+claim stays exactly as it was.** Simplifying must not strengthen or
+weaken a claim — if the original says no general conclusion is drawn
+from a result, that hedge survives the rewrite verbatim.
+
+Use `check_legalese` instead when the text *is* legal: it protects
+terms of art, which `check_officialese` does not.
+
+### 2c. "Is this the right word here?"
+
+Distinct from "give me a synonym", and the tools answer it differently.
+A word can pass `spell_check`, be a valid compound, and still be wrong.
+
+1. Call `synonyms` on the candidate and **read each `definition`**, not
+   just the lemma list. Estonian glosses often carry a domain
+   constraint that settles the question: `korpus` returns "kirjaliku või
+   suulise teksti elektrooniline kogu", so a set of *images* is not a
+   `korpus` however normal that sounds in ML jargon — `andmestik`
+   carries no such constraint.
+2. If the candidate is a compound you or the user coined, call
+   `check_compound_familiarity`. Remember it clears well-formed but
+   stilted compounds — `teadusandmestik` passes at 0.705 even though a
+   native speaker reads it as artificial.
+3. For register fit, call `classify_register` or `check_officialese`.
+4. When the user is a native speaker and corrects your Estonian, they
+   are right. Take the correction and move on.
 
 ### 3. Break repetition in long-form copy
 
@@ -226,10 +281,14 @@ swaps.
 ### `classify_register` is coarse
 
 The classifier is lexicon-based. It flags obvious officialese
-(`käesolev`, `vastavalt`, `sätestama`) and obvious colloquialisms
-(`noh`, `kuule`, `vinge`). It will not catch register cues that live
-in syntax (passive voice, address forms, sentence length). Use it as
-a directional hint, not a verdict.
+(`käesolev`, `vastavalt`, `sätestama`), academic/report vocabulary
+(`aruandeperiood`, `valideerima`, `metoodika`) and obvious
+colloquialisms (`noh`, `kuule`, `vinge`). Its `structure` block adds
+two syntactic signals — umbisikuline tegumood ratio and noun density —
+but only from 25 words up, and address forms and finer syntax still go
+uncaught. Use it as a directional hint, not a verdict; for a full
+kantseliit breakdown with per-issue suggestions, call
+`check_officialese`.
 
 ### `classify_register` returns the tier label in two languages
 

--- a/tests/test_officialese.py
+++ b/tests/test_officialese.py
@@ -1,0 +1,318 @@
+"""Tests for the editorial tools: impersonal-voice counting,
+check_officialese, and check_term_consistency.
+
+These pin the behaviour against a real Estonian R&D report paragraph and
+the plain-language rewrite a native speaker produced from it — the
+bureaucratic original must flag and the human rewrite must come back
+clean. That pair is also what the thresholds in server.py are calibrated
+on, so a threshold change that breaks the separation fails here.
+
+Runs without fastText; the WordNet rule in check_term_consistency
+degrades to off when the resource is missing (asserted via `rules_run`
+rather than assumed).
+
+Run via:
+
+    uv run python tests/test_officialese.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+# The bureaucratic original (an EMTA-facing R&D report) and the rewrite a
+# native Estonian speaker produced from it.
+ORIG_P1 = (
+    "Aruandeperioodil koguti, annoteeriti, valideeriti ja avaldati "
+    "ettevõttesiseselt teadusandmestik, mis koosneb 27 137 "
+    "kinnisvarakuulutuse pildist. Kogu korpus märgendati ühe läbimisega "
+    "Claude'i mudeliga sonnet-4-6 pärast metoodika väljatöötamist, mille "
+    "käigus võrreldi mitme teenusepakkuja multimodaalseid mudeleid ning "
+    "kasutati nende lahknevusi taksonoomia ja viiba täiustamiseks."
+)
+
+ORIG_P2 = (
+    "Märgendid on mudeli loodud ja inimesed ei kontrollinud neid "
+    "ükshaaval, mistõttu mõõdavad kõik täpsusnäitajad kooskõla "
+    "annoteerimisprotsessiga, mitte inimeste antud etalonmärgenditega. "
+    "Lukustatud hindamisosas lahendasid projektimeeskonna liikmed "
+    "pimehindamise korras 179 lahknevust mudeli ennustuse ja märgendi "
+    "vahel, mis pärinesid kahe märgendusvaldkonna kõige vaieldavamatest "
+    "klastritest; vastusevõtmeid hindajatele ei avaldatud ning hindamist "
+    "täiendas eraldi 60 pildi sisuaudit. Selles sihilikult keerulises "
+    "valimis oli korpuse märgend 32% juhtudest vale ja veel 25% juhtudest "
+    "tegelikult mitmeti tõlgendatav; kogu korpust hõlmava veamäära kohta "
+    "väidet ei esitata. Märgendite määratlusi muudeti ning käimas on "
+    "uuesti annoteerimine."
+)
+
+HUMAN_REWRITE = (
+    "Märgendid lõi mudel ise. Inimesed ei kontrollinud neid ükshaaval. "
+    "Seetõttu ei näita täpsusnäitajad, kui õiged märgendid tegelikult on, "
+    "vaid ainult seda, kui hästi need annoteerimisprotsessiga kokku "
+    "lähevad. Selle kontrollimiseks valiti ette kindlaks eraldi valim: "
+    "kahe märgendusvaldkonna kõige vaieldavamad rühmad. Selles valimis "
+    "lahendasid projektimeeskonna liikmed pimehindamise korras 179 "
+    "juhtumit, kus mudeli ennustus ja märgend erinesid. Hindajad ei "
+    "näinud õigeid vastuseid ette. Lisaks vaadati eraldi üle 60 pildi "
+    "sisu. Sellest teadlikult raskest valimist osutus 32% märgenditest "
+    "valeks ja veel 25% tegelikult mitut moodi tõlgendatavaks. Märgendite "
+    "määratlusi täpsustati ja andmestikku annoteeritakse praegu uuesti."
+)
+
+
+def _imp(text: str) -> dict:
+    Text = server._Text()
+    t = Text(text)
+    t.tag_layer(["morph_analysis"])
+    return server._impersonal_voice(list(t.morph_analysis))
+
+
+def impersonal_voice_corrections() -> None:
+    """The four counting bugs, each pinned by the construction that
+    exposed it on real text."""
+    print("impersonal voice — counting corrections")
+
+    # (1) `ei` is tagged pos=V form=neg; counting it inflated total_verbs
+    # and deflated the ratio.
+    r = _imp("Inimesed ei kontrollinud neid.")
+    check("`ei` not counted as a verb", r["total_verbs"] == 1,
+          f"total_verbs={r['total_verbs']}")
+
+    # (2) `ta` form after a negation is the impersonal present negative.
+    r = _imp("Veamäära kohta väidet ei esitata.")
+    check("`ei esitata` counted as impersonal", r["passive_count"] == 1,
+          str(r))
+    # …but a bare da-infinitive is NOT impersonal.
+    r = _imp("Meeskond otsustas esitada aruande.")
+    check("bare da-infinitive not counted", r["passive_count"] == 0, str(r))
+
+    # (3) `ei avaldatud` gets tagged pos=A, not V — was skipped entirely.
+    r = _imp("Vastusevõtmeid hindajatele ei avaldatud.")
+    check("`ei avaldatud` counted despite pos=A tag",
+          r["passive_count"] == 1, str(r))
+
+    # (4) attributive -tud participle is a modifier, not a predicate.
+    r = _imp("Lukustatud hindamisosas lahendasid liikmed juhtumeid.")
+    check("attributive -tud not counted as impersonal",
+          r["passive_count"] == 0, str(r))
+    check("attributive -tud reported separately",
+          "Lukustatud" in r["attributive_excluded"], str(r))
+    # …but with an olema-form in front it IS an impersonal predicate.
+    r = _imp("Andmeid on kasutatud mitmel korral.")
+    check("`on kasutatud` counted as impersonal", r["passive_count"] == 1,
+          str(r))
+
+    # `mitte` negates a noun phrase, not a verb — must not trigger.
+    r = _imp("Mõõdeti kooskõla, mitte inimeste antud märgenditega.")
+    check("`mitte X antud` not counted as impersonal predicate",
+          "antud" not in r["examples"], str(r))
+
+    # Core case: the report paragraph is overwhelmingly impersonal.
+    r = _imp(ORIG_P1)
+    check("bureaucratic paragraph reads as heavily impersonal",
+          r["ratio"] >= 0.8, str(r))
+
+
+def officialese_separation() -> None:
+    """The gates must separate the bureaucratic original from the human
+    rewrite — that separation IS the calibration."""
+    print("check_officialese — original vs human rewrite")
+
+    o1 = server.check_officialese(ORIG_P1)
+    o2 = server.check_officialese(ORIG_P2)
+    human = server.check_officialese(HUMAN_REWRITE)
+
+    check("original P1 flags issues", len(o1["issues"]) > 0,
+          str(o1["summary_estonian"]))
+    check("original P2 flags issues", len(o2["issues"]) > 0,
+          str(o2["summary_estonian"]))
+    check("human rewrite comes back clean", len(human["issues"]) == 0,
+          str([i["rule"] for i in human["issues"]]))
+
+    rules1 = {i["rule"] for i in o1["issues"]}
+    check("P1 flags impersonal voice", "impersonal-voice" in rules1, str(rules1))
+    check("P1 flags nominalisation", "nominalisation" in rules1, str(rules1))
+    check("P1 flags a long sentence", "long-sentence" in rules1, str(rules1))
+
+    # Metrics move in the direction the human edit moved them.
+    check("nominalisation density drops across the rewrite",
+          human["metrics"]["nominalisations_per_100_words"]
+          < o1["metrics"]["nominalisations_per_100_words"],
+          f"{o1['metrics']['nominalisations_per_100_words']} → "
+          f"{human['metrics']['nominalisations_per_100_words']}")
+    check("impersonal ratio drops across the rewrite",
+          human["metrics"]["impersonal_voice"]["ratio"]
+          < o1["metrics"]["impersonal_voice"]["ratio"],
+          f"{o1['metrics']['impersonal_voice']['ratio']} → "
+          f"{human['metrics']['impersonal_voice']['ratio']}")
+
+    # Every issue carries an Estonian label (no English-only output).
+    for label, res in (("P1", o1), ("P2", o2)):
+        check(f"{label}: every issue has rule_estonian",
+              all(i.get("rule_estonian") for i in res["issues"]),
+              str([i.get("rule_estonian") for i in res["issues"]]))
+        check(f"{label}: every issue has a suggestion",
+              all(i.get("suggestion") for i in res["issues"]))
+
+    # -mine nouns come back with the verb to swap in.
+    noms = {n["lemma"]: n["verb"] for n in o1["metrics"]["nominalisations"]}
+    check("nominalisation carries its verb (väljatöötamine → väljatöötama)",
+          noms.get("väljatöötamine") == "väljatöötama", str(noms))
+
+
+def officialese_lexicons() -> None:
+    print("check_officialese — filler, phrases, poolt-calque, clause stacking")
+    probe = (
+        "Projekti raames viidi läbi analüüs, mis kujutab endast olulist "
+        "etappi. Mudeli poolt loodud märgendid omavad tähtsust. "
+        "Analüüs teostati lähtuvalt metoodikast."
+    )
+    r = server.check_officialese(probe)
+    rules = {i["rule"] for i in r["issues"]}
+    sugg = {(i.get("word") or i.get("phrase", "")).lower(): i["suggestion"]
+            for i in r["issues"]}
+
+    check("flags 'viidi läbi'", "viidi läbi" in sugg, str(sorted(sugg)))
+    check("flags 'kujutab endast'", "kujutab endast" in sugg, str(sorted(sugg)))
+    check("flags the poolt-calque", "poolt-calque" in rules, str(rules))
+    check("flags 'omama'", any(k.startswith("oma") for k in sugg), str(sorted(sugg)))
+    check("flags 'teostama'", any(k.startswith("teosta") for k in sugg),
+          str(sorted(sugg)))
+
+    # Surface-matched filler: the inflected form is the marker, while the
+    # lemma (eesmärk / vahendus) is an ordinary word that must stay quiet.
+    r = server.check_officialese(
+        "Analüüsi eesmärgil kasutati andmeid. Süsteemi vahendusel saadeti teade."
+    )
+    words = {(i.get("word") or "").lower() for i in r["issues"]}
+    check("flags 'eesmärgil'", "eesmärgil" in words, str(sorted(words)))
+    check("flags 'vahendusel'", "vahendusel" in words, str(sorted(words)))
+    r = server.check_officialese("Meie eesmärk on selge ja vahendus toimis hästi.")
+    check("plain 'eesmärk' / 'vahendus' not flagged",
+          not [i for i in r["issues"] if i["rule"] == "officialese-filler"],
+          str([i.get("word") for i in r["issues"]]))
+
+    # 'hääletas poolt' is "in favour", not the passive-agent calque.
+    r = server.check_officialese("Enamik liikmeid hääletas poolt ja ettepanek kinnitati.")
+    check("'hääletas poolt' not flagged as a calque",
+          "poolt-calque" not in {i["rule"] for i in r["issues"]},
+          str([i["rule"] for i in r["issues"]]))
+
+    # Clause stacking beats raw length as the reason for the flag.
+    stacked = (
+        "Töötati välja metoodika, mille käigus võrreldi mudeleid, mis "
+        "erinesid taksonoomia poolest, kuna varasem lahendus ei sobinud."
+    )
+    r = server.check_officialese(stacked)
+    check("clause stacking flagged",
+          "clause-stacking" in {i["rule"] for i in r["issues"]},
+          str([i["rule"] for i in r["issues"]]))
+
+    # Plain, short Estonian must stay silent.
+    r = server.check_officialese("Eile käisin kinos. Film oli hea ja näitlejad mängisid hästi.")
+    check("plain prose flags nothing", len(r["issues"]) == 0,
+          str([i["rule"] for i in r["issues"]]))
+
+
+def term_consistency() -> None:
+    print("check_term_consistency")
+    doc = (
+        "Aruandeperioodil avaldati teadusandmestik. Pildiandmestik koosneb "
+        "27137 pildist. Andmestik on ettevõttesisene. Treeningandmestik "
+        "valmis mais."
+    )
+    r = server.check_term_consistency(doc)
+    check("rules_run reports the head rule ran",
+          r["rules_run"]["shared-compound-head"] is True, str(r["rules_run"]))
+
+    head_groups = [g for g in r["groups"] if g["rule"] == "shared-compound-head"]
+    check("the andmestik variants are grouped", len(head_groups) >= 1,
+          str(r["groups"]))
+    if head_groups:
+        g = head_groups[0]
+        lemmas = {v["lemma"] for v in g["variants"]}
+        check("group holds all four variants",
+              {"andmestik", "teadusandmestik", "pildiandmestik",
+               "treeningandmestik"} <= lemmas, str(lemmas))
+        check("group has an Estonian rule label",
+              g.get("rule_estonian") == "sama põhisõna", str(g.get("rule_estonian")))
+        check("group names a dominant term", bool(g.get("dominant")), str(g))
+
+    # Two compounds sharing a head, with no bare head, is deliberately
+    # NOT enough — those are usually genuinely different things.
+    r = server.check_term_consistency(
+        "Tegevusvaldkond on lai. Märgendusvaldkond on kitsam."
+    )
+    check("two compounds sharing a head alone do not flag",
+          not [g for g in r["groups"] if g["rule"] == "shared-compound-head"],
+          str(r["groups"]))
+
+    # Consistent prose stays quiet.
+    r = server.check_term_consistency(
+        "Andmestik valmis mais. Andmestik sisaldab pilte. Andmestik on avalik."
+    )
+    check("consistent terminology flags nothing", len(r["groups"]) == 0,
+          str(r["groups"]))
+
+
+def familiarity_decisiveness_guard() -> None:
+    """The junk-tail gate must not fire when a real, >= 0.60 top neighbour
+    vouches for the compound. Captured production fastText data."""
+    print("familiarity — junk-tail decisiveness guard")
+
+    # pildiandmestik: ordinary compound, top neighbour is its own head at
+    # 0.71, but 5/8 of the tail is scrape junk. Must NOT flag.
+    is_suspect, reasons, _q = server._familiarity_verdict(
+        False, 0.71, [
+            ("andmestik", 0.71), ("andmestiku", 0.59), ("juhtmestik", 0.526),
+            ("graafikaKunst", 0.506), ("kunstitarbedMõõdutabelidTellimise", 0.496),
+            ("ÜhisgümnaasiumKudumidPolosärgidPüksid", 0.49),
+            ("ErakoolKudumidPolosärgidPluusid", 0.48),
+            ("kihtFliisidPluusidPüksid", 0.47),
+        ], ["pildi", "andmestik"])
+    check("pildiandmestik not flagged (real top neighbour vouches)",
+          is_suspect is False, str(reasons))
+
+    # sisuaudit: 0.605 top score but the top neighbour is ITSELF junk —
+    # the tail is decisive here, so it must still flag.
+    is_suspect, reasons, _q = server._familiarity_verdict(
+        False, 0.605, [
+            ("ÜhisgümnaasiumKudumidPolosärgidPüksid", 0.605),
+            ("põhjalTripAdvisori", 0.603), ("terviktekstRedaktsiooni", 0.603),
+            ("SOTSIAALMEEDIASMOBIILIRAKENDUS", 0.598),
+            ("ErakoolKudumidPolosärgidPluusid", 0.595),
+            ("kihtFliisidPluusidPüksid", 0.59),
+            ("graafikaKunst", 0.588), ("PortaalUudised", 0.585),
+        ], ["sisu", "audit"])
+    check("sisuaudit still flagged (top neighbour is junk)",
+          is_suspect is True, str(reasons))
+
+
+impersonal_voice_corrections()
+officialese_separation()
+officialese_lexicons()
+term_consistency()
+familiarity_decisiveness_guard()
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("\nall officialese / term-consistency tests passed")


### PR DESCRIPTION
Came out of replaying a real Estonian editing conversation through the server: a native speaker rewriting an R&D report for readability, asking "is this the right word here?", and being told `korpus` is wrong for image data. **The MCP was never invoked in that conversation** — and when the text was replayed through the tools, most stayed silent or gave the wrong verdict. 24 tools → 26.

## Added

- **`check_officialese`** — kantseliit check for **non-legal** Estonian. `check_legalese` returned **zero issues** on a real R&D report paragraph: its filler lexicon is legal-specific and its 34-word gate sits above where Estonian prose actually becomes unreadable. Measures nominalisation density (each `-mine` noun paired with the verb to swap in), umbisikuline tegumood, clause stacking (`mille käigus … ning …`), an Estonian-calibrated 25-word gate, and admin filler (`omab` → `on`, `viidi läbi` → `tehti`, `mudeli poolt loodud` → `mudeli loodud`).
- **`check_term_consistency`** — one referent, one term. Shared compound head + shared WordNet synset, with per-variant counts. Two compounds sharing a head is deliberately *not* enough to flag.

## Fixed

- **`check_style` mis-counted umbisikuline tegumood four ways**, each verified against Vabamorf tags: `ei`/`ära` (tagged `pos=V form=neg`) inflated `total_verbs`; the `ta`/`da` impersonal-present-negative form was missing entirely; `ei avaldatud` (tagged `pos=A`) was skipped; attributive `-tud` participles were counted as passive and now surface under `attributive_excluded`.
- **`check_compound_familiarity`'s junk gate inverted human judgement** — `pildiandmestik` (top neighbour `andmestik` @ 0.71) was flagged while `teadusandmestik` (0.705), the word a native speaker called artificial, passed. The junk-tail gate is now decisive only when the compound is also weak at the top or its top neighbour is itself junk. `mõtteliin` and `toortõlkeoht` still flag.

## Changed

- **`classify_register` scored dense officialese as `neutraalne`/0.0 with zero markers** while 87.5% of that text's verbs were impersonal. Adds academic/report vocabulary plus a bounded structural component (+0.4 max, 25 words up, never applied to net-colloquial text).
- `synonyms` documents the **word-fit check** — read each gloss's domain constraint. The server already knew `korpus` = "kirjaliku või suulise teksti elektrooniline kogu"; nothing told the model to test it against context.
- Server instructions route editorial questions, not just mechanical ones.

## Calibration

Thresholds are pinned to a native speaker's own rewrite of the report. Across that edit:

| metric | original | rewrite | gate |
| --- | --- | --- | --- |
| impersonal ratio | 0.875 | 0.308 | 0.4 |
| `-mine` per 100 words | 7.89 | 2.33 | 4.0 |
| longest sentence | 30 | 21 | 25 |
| noun/verb ratio | 2.50 | 2.23 | 2.5 (weakest — flagged as such) |

The bureaucratic original flags on three rules; the human rewrite comes back clean. `tests/test_officialese.py` pins that separation, so a threshold change that breaks it fails CI.

## Security / privacy

No new network, filesystem, logging or persistence surface — both tools are pure local computation over EstNLTK and in-module lexicons, `readOnlyHint: true`, size-capped. Two things deliberately handled:

- `check_term_consistency` is capped at **100k chars, not 500k**. Unlike `check_defined_terms` (pure regex) it runs full morphological analysis; 500k would burn ~22s CPU per call and blow the budget the public per-IP rate limit is sized against. At 100k it costs 4.6s, in line with existing `check_style` (7.6s).
- The WordNet lookup redirects stdout to stderr and catches `BaseException`. If the resource were ever absent, EstNLTK would prompt on **stdout** — which in stdio transport *is* the MCP protocol channel. Rule B degrades to off and `rules_run` reports it.

## Tests

`test_officialese.py` (42 checks, new) + familiarity 26 + legal 30 + HTTP 74, all passing. No regressions in the existing suite.