### PR TITLE
0.5.1: nominalisation label carries both Estonian terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-07-31
+
+### Changed
+
+- **`check_officialese`'s nominalisation label now carries both Estonian
+  terms**: `nimisõnastumine ehk nominalisatsioon` (was `nimisõnastumine
+  (mine-vormide rohkus)`). Both names are in use and a reader may know
+  only one; the concrete `-mine` detail already appears in each issue's
+  `explanation` field, so the parenthetical was redundant. Output-only
+  change, no logic touched.
+
 ## [0.5.0] — 2026-07-31
 
 Editorial release. Everything here came out of replaying a real Estonian

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.0"
+SERVER_VERSION = "0.5.1"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -3384,7 +3384,7 @@ def _check_officialese(text: str) -> dict:
         issues.append({
             "position": nominalisations[0]["position"] if nominalisations else 0,
             "rule": "nominalisation",
-            "rule_estonian": "nimisõnastumine (mine-vormide rohkus)",
+            "rule_estonian": "nimisõnastumine ehk nominalisatsioon",
             "explanation": (
                 f"Tekstis on {len(nominalisations)} mine-tuletist "
                 f"{word_count} sõna kohta. Tegevust väljendav nimisõna "


### PR DESCRIPTION
Follow-up to #33, requested by a native speaker reviewing the Estonian labels.

`check_officialese`'s nominalisation issue now reports `rule_estonian: "nimisõnastumine ehk nominalisatsioon"` (was `"nimisõnastumine (mine-vormide rohkus)"`). Both terms are in use and a reader may know only one; the concrete `-mine` detail already appears in each issue's `explanation` field, so the parenthetical was redundant.

Output-only change, no logic touched. Patch bump to 0.5.1 so the deployed `/health` version keeps matching its git tag.