### PR TITLE
0.5.2: mcp_methods breakdown at /metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-08-23
+
+### Added
+
+- **`mcp_methods` at `/metrics`** — POST `/mcp` traffic bucketed by JSON-RPC
+  method. This exists to answer a question the old counters could not:
+  `tool_calls_total / sessions_total` was 0.53, i.e. more than half of
+  `initialize` calls never led to a tool call, with no way to tell probes
+  from real clients bouncing. Now `initialize` vs
+  `notifications/initialized` shows how many handshakes actually completed
+  rather than being abandoned mid-probe, and `tools/list` vs `tools/call`
+  shows how many clients enumerate the tools but never call one.
+
+  Method names are bucketed against a **fixed allowlist**; anything else
+  counts as `other`. The method comes from a request body and is therefore
+  caller-controlled, so it is never stored verbatim — that keeps the
+  metrics dict bounded against a hostile client inventing method names and
+  keeps arbitrary caller strings off `/metrics`. Still PII-free: only the
+  `method` field is read, never params, arguments or clientInfo.
+
+  Deliberately NOT "sessions that made >=1 tool call". The transport runs
+  `stateless_http`, so an `initialize` cannot be tied to the calls that
+  follow it, and introducing a client identifier to make that possible
+  would be a privacy step backwards. The method mix answers the same
+  question from the other side.
+
+### Changed
+
+- `_is_initialize_request` is replaced by `_classify_mcp_method`, which
+  parses the method once and buckets it. The old helper could skip the
+  JSON parse via a substring gate; the new one parses every POST `/mcp`
+  body. The body is already fully buffered at that point and a `json.loads`
+  on even a 100k-char tool call is well under a millisecond against tool
+  executions that run 10ms-7s, so the visibility is worth the trade. Method
+  names are still matched by parsing rather than substring, so a tool call
+  whose Estonian text merely contains `initialize` is not miscounted —
+  pinned by test.
+
+### Security
+
+- **cryptography 48.0.1 → 50.0.0** (CVE-2026-69247, high): a Bleichenbacher
+  oracle in PKCS#7 EnvelopedData decryption via distinguishable errors and
+  timing. Transitive only (`mcp` → `pyjwt` → `cryptography`) and not in the
+  exploitable path — the server never touches JWT or PKCS#7; bearer auth is
+  a `secrets.compare_digest` comparison, and public mode has no auth at
+  all. Patched regardless.
+
 ## [0.5.1] — 2026-07-31
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.1"
+version = "0.5.2"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.1"
+SERVER_VERSION = "0.5.2"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -3882,6 +3882,16 @@ _STATS: dict[str, Any] = {
     # reconnects counts again, and automated probes count too. No identity,
     # no IP, no body is stored — only the fact that an initialize occurred.
     "sessions": 0,
+    # JSON-RPC method mix on POST /mcp, bucketed to a FIXED allowlist (see
+    # _MCP_METHODS). Stateless HTTP means an `initialize` cannot be tied to
+    # the tool calls that follow it, so "sessions that made >=1 tool call"
+    # is not computable without inventing a client identifier — which would
+    # be a privacy step backwards. This breakdown answers the same question
+    # from the other side: `initialize` vs `notifications/initialized` shows
+    # how many handshakes were actually completed rather than abandoned by a
+    # probe, and `tools/list` vs `tools/call` shows how many clients
+    # enumerate the tools but never use one.
+    "mcp_methods": {},
 }
 
 # Ring buffer of recent 5xx errors so they're inspectable at /metrics
@@ -3912,6 +3922,10 @@ def _load_persistent_stats() -> None:
         _STATS["by_status"] = {str(k): int(v) for k, v in (data.get("by_status") or {}).items()}
         _STATS["by_path"] = {str(k): int(v) for k, v in (data.get("by_path") or {}).items()}
         _STATS["sessions"] = int(data.get("sessions", 0))
+        _STATS["mcp_methods"] = {
+            str(k): int(v) for k, v in (data.get("mcp_methods") or {}).items()
+            if str(k) in _MCP_METHODS or str(k) == "other"
+        }
         _TOOL_CALLS.clear()
         _TOOL_CALLS.update({str(k): int(v) for k, v in (data.get("tool_calls") or {}).items()})
         _recent_errors.clear()
@@ -3938,6 +3952,7 @@ def _save_persistent_stats() -> None:
             "by_status": _STATS["by_status"],
             "by_path": _STATS["by_path"],
             "sessions": _STATS["sessions"],
+            "mcp_methods": _STATS["mcp_methods"],
             "tool_calls": _TOOL_CALLS,
             "recent_errors": list(_recent_errors),
             "saved_at_unix": int(time.time()),
@@ -3947,24 +3962,52 @@ def _save_persistent_stats() -> None:
         log.warning("metrics persistence: failed to save %s: %s", _METRICS_PATH, e)
 
 
-def _is_initialize_request(body: bytes) -> bool:
-    """True if an MCP request body is a JSON-RPC `initialize` call.
+# Fixed allowlist of JSON-RPC methods we bucket into `mcp_methods`.
+# The method name comes from a request body, i.e. it is caller-controlled,
+# so it is NEVER stored verbatim — anything outside this set is counted as
+# "other". That keeps the metrics dict bounded (no unbounded key growth
+# from a hostile client) and keeps arbitrary caller strings off /metrics.
+_MCP_METHODS: frozenset[str] = frozenset({
+    "initialize",
+    "notifications/initialized",
+    "tools/list",
+    "tools/call",
+    "prompts/list",
+    "resources/list",
+    "resources/templates/list",
+    "ping",
+})
 
-    Used to count client connections (sessions) at /metrics. We parse only
-    to read the `method` field — never the params/clientInfo — and store
-    nothing from the body. The cheap substring gate skips the JSON parse
-    for the overwhelming majority of requests (tool calls), and parsing
-    the method (rather than substring-matching) means a tool call whose
-    text argument merely contains the word "initialize" is NOT counted."""
-    if b"initialize" not in body:
-        return False
+
+def _classify_mcp_method(body: bytes) -> str | None:
+    """Bucket an MCP request body by its JSON-RPC method name.
+
+    Returns an allowlisted method name, "other" for anything unrecognised,
+    or None if the body is not parseable JSON-RPC. Only the `method` field
+    is read — never params, arguments, or clientInfo — and nothing from the
+    body is stored.
+
+    Cost note: this parses every POST /mcp body, where the old
+    initialize-only check could skip the parse via a substring gate. The
+    body is already fully buffered by _drain_body at this point, and a
+    json.loads on even a 100k-char tool call is well under a millisecond
+    against tool executions that run 10ms-7s, so the trade is worth the
+    visibility. Method names are matched by parsing rather than substring
+    so a tool call whose Estonian text merely contains "tools/call" is not
+    miscounted.
+    """
     try:
         msg = json.loads(body)
     except (ValueError, UnicodeDecodeError):
-        return False
-    if isinstance(msg, list):  # JSON-RPC batch
-        return any(isinstance(m, dict) and m.get("method") == "initialize" for m in msg)
-    return isinstance(msg, dict) and msg.get("method") == "initialize"
+        return None
+    if isinstance(msg, list):  # JSON-RPC batch — classify by its first method
+        msg = next((m for m in msg if isinstance(m, dict) and m.get("method")), None)
+    if not isinstance(msg, dict):
+        return None
+    method = msg.get("method")
+    if not isinstance(method, str):
+        return None
+    return method if method in _MCP_METHODS else "other"
 
 
 async def _drain_body(receive):
@@ -4303,6 +4346,7 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                     "tool_calls_total": sum(_TOOL_CALLS.values()),
                     "tool_calls": dict(_TOOL_CALLS),
                     "sessions_total": _STATS["sessions"],
+                    "mcp_methods": dict(_STATS["mcp_methods"]),
                     "recent_errors": list(_recent_errors),
                     "uptime_seconds": int(time.time() - _STATS_START_TS),
                     "started_at_unix": int(_STATS_START_TS),
@@ -4317,6 +4361,19 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                         "too. No identity, IP, or request body is ever stored "
                         "— only the fact of an initialize. Daily connections "
                         "= the day-over-day delta in the metrics snapshot. "
+                        "mcp_methods buckets POST /mcp by JSON-RPC method "
+                        "against a FIXED allowlist (anything else counts as "
+                        "'other', so a caller-supplied method name can never "
+                        "become a metrics key). Read it to tell probes from "
+                        "real clients: initialize vs notifications/initialized "
+                        "shows how many handshakes completed rather than being "
+                        "abandoned, and tools/list vs tools/call shows how many "
+                        "clients enumerate the tools but never call one. NOTE "
+                        "this is NOT 'sessions that made >=1 tool call': the "
+                        "transport is stateless_http, so an initialize cannot "
+                        "be tied to the calls that follow it, and adding a "
+                        "client identifier to make that possible would be a "
+                        "privacy step backwards. "
                         "Counters persist to "
                         "/data/metrics.json every 30 s when a Fly volume is "
                         "mounted, surviving restarts; without a volume "
@@ -4405,18 +4462,25 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
                 await _send_status(send, 429, {"error": "rate_limited"})
                 return
 
-            # Count MCP `initialize` calls as a privacy-safe session proxy.
-            # Only an authorized, non-rate-limited POST /mcp can carry one;
-            # for those we buffer the small JSON-RPC body to peek at the
-            # method, then replay it to the inner app byte-for-byte. Nothing
-            # from the body is stored — only _STATS["sessions"] is bumped on
-            # the fact of an initialize. All other traffic (GET SSE streams,
-            # other paths) passes straight through with the original receive.
+            # Bucket MCP traffic by JSON-RPC method. Only an authorized,
+            # non-rate-limited POST /mcp gets here; for those we buffer the
+            # JSON-RPC body to peek at the `method`, then replay it to the
+            # inner app byte-for-byte. Nothing from the body is stored — we
+            # bump _STATS["sessions"] on the fact of an initialize, and
+            # bucket the method into a FIXED allowlist so a caller-supplied
+            # string can never become a metrics key. All other traffic (GET
+            # SSE streams, other paths) passes straight through with the
+            # original receive.
             receive_for_inner = receive
             if scope.get("method") == "POST" and path in ("/mcp", "/mcp/"):
                 consumed, body = await _drain_body(receive)
-                if _is_initialize_request(body):
-                    _STATS["sessions"] += 1
+                method = _classify_mcp_method(body)
+                if method is not None:
+                    _STATS["mcp_methods"][method] = (
+                        _STATS["mcp_methods"].get(method, 0) + 1
+                    )
+                    if method == "initialize":
+                        _STATS["sessions"] += 1
                 receive_for_inner = _replay_receive(consumed, receive)
 
             await inner(scope, receive_for_inner, send)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -293,6 +293,7 @@ def metrics_persistence_test() -> None:
     saved_pathd = dict(server._STATS["by_path"])
     saved_errors = list(server._recent_errors)
     saved_sessions = server._STATS.get("sessions", 0)
+    saved_methods = dict(server._STATS.get("mcp_methods", {}))
     try:
         with tempfile.TemporaryDirectory() as d:
             server._METRICS_PATH = Path(d) / "metrics.json"
@@ -300,6 +301,7 @@ def metrics_persistence_test() -> None:
             server._STATS["by_status"] = {"200": 12000, "429": 345}
             server._STATS["by_path"] = {"/mcp": 12300, "/health": 45}
             server._STATS["sessions"] = 678
+            server._STATS["mcp_methods"] = {"initialize": 678, "tools/call": 91, "other": 2}
             server._recent_errors.clear()
             server._recent_errors.append({"ts": 1700000000, "path": "/mcp", "status": 500, "error": "RuntimeError"})
             server._save_persistent_stats()
@@ -309,12 +311,16 @@ def metrics_persistence_test() -> None:
             server._STATS["by_status"] = {}
             server._STATS["by_path"] = {}
             server._STATS["sessions"] = 0
+            server._STATS["mcp_methods"] = {}
             server._recent_errors.clear()
             server._load_persistent_stats()
             check("total restored", server._STATS["total"] == 12345)
             check("by_status restored", server._STATS["by_status"] == {"200": 12000, "429": 345})
             check("by_path restored", server._STATS["by_path"] == {"/mcp": 12300, "/health": 45})
             check("sessions restored", server._STATS["sessions"] == 678, str(server._STATS["sessions"]))
+            check("mcp_methods restored",
+                  server._STATS["mcp_methods"] == {"initialize": 678, "tools/call": 91, "other": 2},
+                  str(server._STATS["mcp_methods"]))
             check("recent_errors restored", list(server._recent_errors) == [
                 {"ts": 1700000000, "path": "/mcp", "status": 500, "error": "RuntimeError"}], str(list(server._recent_errors)))
             # graceful no-op when parent dir is gone (local dev path)
@@ -330,26 +336,43 @@ def metrics_persistence_test() -> None:
         server._STATS["by_status"] = saved_status
         server._STATS["by_path"] = saved_pathd
         server._STATS["sessions"] = saved_sessions
+        server._STATS["mcp_methods"] = saved_methods
         server._recent_errors.clear()
         server._recent_errors.extend(saved_errors)
 
 
-def is_initialize_unit_test() -> None:
-    """Pure checks for the initialize detector — the heart of the session
-    counter. Critically, a tool call whose text merely contains the word
-    'initialize' must NOT be counted."""
-    print("_is_initialize_request (unit)")
+def classify_mcp_method_unit_test() -> None:
+    """Pure checks for the JSON-RPC method classifier — the heart of the
+    session counter and the mcp_methods breakdown. Critically, a tool call
+    whose text merely contains the word 'initialize' must NOT be counted as
+    one, and a caller-supplied method name must never become a metrics key."""
+    print("_classify_mcp_method (unit)")
+    cm = server._classify_mcp_method
     init = b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"x"}}'
-    check("initialize → True", server._is_initialize_request(init) is True)
+    check("initialize → 'initialize'", cm(init) == "initialize")
     tool = b'{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spell_check"}}'
-    check("tools/call → False", server._is_initialize_request(tool) is False)
+    check("tools/call → 'tools/call'", cm(tool) == "tools/call")
+    check("tools/call is not counted as initialize", cm(tool) != "initialize")
     sneaky = b'{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"spell_check","arguments":{"text":"please initialize the session"}}}'
-    check("tool call mentioning 'initialize' in text → False",
-          server._is_initialize_request(sneaky) is False)
-    check("empty body → False", server._is_initialize_request(b"") is False)
-    check("malformed JSON → False", server._is_initialize_request(b'{not json initialize') is False)
+    check("tool call mentioning 'initialize' in text → 'tools/call'",
+          cm(sneaky) == "tools/call")
+    lister = b'{"jsonrpc":"2.0","id":4,"method":"tools/list"}'
+    check("tools/list → 'tools/list'", cm(lister) == "tools/list")
+    noti = b'{"jsonrpc":"2.0","method":"notifications/initialized"}'
+    check("notifications/initialized bucketed",
+          cm(noti) == "notifications/initialized")
+    check("empty body → None", cm(b"") is None)
+    check("malformed JSON → None", cm(b'{not json initialize') is None)
     batch = b'[{"jsonrpc":"2.0","id":1,"method":"initialize"},{"jsonrpc":"2.0","method":"ping"}]'
-    check("batch with initialize → True", server._is_initialize_request(batch) is True)
+    check("batch classified by first method", cm(batch) == "initialize")
+    # Caller-controlled method names must be bucketed, never stored verbatim.
+    hostile = b'{"jsonrpc":"2.0","id":5,"method":"evil/../../etc/passwd"}'
+    check("unknown method → 'other' (never verbatim)", cm(hostile) == "other")
+    huge = b'{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"spell_check","arguments":{"text":"' + b'ab'*40000 + b'"}}}'
+    check("100k-char tool call still classified", cm(huge) == "tools/call")
+    check("no unbounded key growth: every result is allowlisted",
+          all(cm(b) in server._MCP_METHODS or cm(b) in ("other", None)
+              for b in (init, tool, sneaky, lister, noti, batch, hostile, huge, b"")))
 
 
 async def inner_exc_capture_test() -> None:
@@ -406,7 +429,7 @@ async def session_counter_test() -> None:
 
 asyncio.run(run())
 metrics_persistence_test()
-is_initialize_unit_test()
+classify_mcp_method_unit_test()
 asyncio.run(session_counter_test())
 asyncio.run(inner_exc_capture_test())
 


### PR DESCRIPTION
Answers the question the existing counters couldn't: `tool_calls_total / sessions_total` was **0.53** — more than half of `initialize` calls never led to a tool call, with no way to tell automated probes from real clients bouncing.

## What it adds

`mcp_methods` at `/metrics`, bucketing POST `/mcp` by JSON-RPC method:

```json
"mcp_methods": {"initialize": 1, "notifications/initialized": 1,
                "tools/list": 1, "tools/call": 2, "other": 1}
```

- `initialize` vs `notifications/initialized` → how many handshakes actually **completed** rather than being abandoned mid-probe.
- `tools/list` vs `tools/call` → how many clients **enumerate** the tools but never call one.

## What it deliberately is not

**Not "sessions that made ≥1 tool call".** The transport runs `stateless_http` (`server.py:4228`), so an `initialize` genuinely cannot be tied to the calls that follow it. Making that possible would mean either dropping stateless mode or introducing a client identifier — a privacy step backwards for a metrics nicety. The method mix answers the same underlying question from the other side, and the `/metrics` note says so explicitly rather than letting the field be misread.

## Privacy / safety

- Method names come from a request body, so they are **caller-controlled**. They are bucketed against a fixed allowlist (`_MCP_METHODS`) and **never stored verbatim** — a hostile client can't grow the metrics dict with invented method names, and no caller string reaches `/metrics`. Pinned by test: `evil/../../etc/passwd` → `other`.
- Only the `method` field is read. Never params, arguments, or clientInfo. Nothing from the body is stored.
- No new network, filesystem, or logging surface.

## Cost

`_is_initialize_request` is replaced by `_classify_mcp_method`. The old helper could skip the JSON parse via a `b"initialize" not in body` substring gate; the new one parses every POST `/mcp` body. The body is already fully buffered by `_drain_body` at that point, and a `json.loads` on even a 100k-char tool call is well under a millisecond against tool executions that run 10ms–7s. Method names are still matched by **parsing**, not substring, so a tool call whose Estonian text contains `initialize` is not miscounted — pinned by test.

## Tests

`_is_initialize_request`'s tests are **ported and extended**, not dropped — the dead helper is removed rather than left tested and unused. HTTP suite 74 → 81 checks, including the hostile-method bucketing, a 100k-char body, and `mcp_methods` surviving the persistence round-trip. Verified end-to-end against a live local server.

Also carries the merged **cryptography 48.0.1 → 50.0.0** bump (CVE-2026-69247, high) from #35 — transitive via `mcp` → `pyjwt`, not in the exploitable path since the server never touches JWT or PKCS#7.