### PR TITLE
0.5.3: fix silent half-strength runs and the source-install resource gap (#37, #38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,28 @@ jobs:
       - name: Run officialese / term-consistency tests
         run: uv run --python ${{ matrix.python-version }} python tests/test_officialese.py
 
+      - name: Run resource-availability tests (issues #37, #38)
+        run: uv run --python ${{ matrix.python-version }} python tests/test_resources.py
+
+      # The setup path a source install actually follows. Runs last so a
+      # break here is unambiguous, and proves the script is idempotent
+      # against resources CI already fetched by other means.
+      - name: Verify scripts/fetch_resources.py is idempotent
+        run: uv run --python ${{ matrix.python-version }} python scripts/fetch_resources.py
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v7
+      # Config lives in ruff.toml and encodes this repo's actual
+      # conventions, so a failure here means a real deviation rather than
+      # a disagreement about style.
+      - name: ruff
+        run: uvx ruff check . --output-format=github
+
   docker:
     runs-on: ubuntu-latest
     needs: smoke
@@ -147,6 +169,21 @@ jobs:
           echo "--- tools/call find_related_words (fastText, must not error)"
           call_tool find_related_words '{"word":"kohv"}' \
             | python3 -c "import sys,json; r=json.load(sys.stdin).get('result',{}); assert not r.get('isError'), 'find_related_words errored: '+str(r); print('find_related_words OK')"
+
+          # issue #37: check_compounds needs NLTK punkt_tab, which uv.lock
+          # cannot install. The image worked by accident; assert it works by
+          # construction so a base-image change cannot silently break every
+          # one-click user.
+          echo "--- tools/call check_compounds (punkt_tab, must not error)"
+          call_tool check_compounds '{"text":"Kooli maja on suur."}' \
+            | python3 -c "import sys,json; r=json.load(sys.stdin).get('result',{}); assert not r.get('isError'), 'check_compounds errored: '+str(r); print('check_compounds OK')"
+
+          # issue #38: the image must run this tool at FULL strength. A
+          # degraded:true here means WordNet went missing from the image and
+          # callers would be getting confident-but-partial answers.
+          echo "--- tools/call check_term_consistency (must NOT be degraded)"
+          call_tool check_term_consistency '{"text":"Andmestik ja teadusandmestik."}' \
+            | python3 -c "import sys,json; r=json.load(sys.stdin).get('result',{}); assert not r.get('isError'), 'check_term_consistency errored: '+str(r); o=json.loads(r['content'][0]['text']); assert o['rules_run']['shared-wordnet-synset'] is True, 'WordNet rule did not run in the image: '+str(o['rules_run']); assert o.get('degraded') is False, 'image is serving degraded results: '+str(o); print('check_term_consistency OK, not degraded')"
 
           docker logs mcp | tail -20
           docker rm -f mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,35 +37,39 @@ jobs:
       - name: Install dependencies (locked)
         run: uv sync --frozen --python ${{ matrix.python-version }}
 
-      - name: Pre-download EstNLTK WordNet (used by synonyms tool)
-        # Try EstNLTK's built-in S3 download; fall back to our GH
-        # Release mirror if the upstream S3 (hpc.ut.ee) is down.
+      # The documented setup path, not a bespoke one. This job used to
+      # hand-roll the WordNet + fastText fetches and let EstNLTK silently
+      # auto-download punkt_tab on first use — which is exactly the
+      # behaviour the server now refuses, so a divergent CI would have gone
+      # green while users hit issues #37/#38.
+      - name: Fetch resources (the documented setup step)
+        run: uv run --python ${{ matrix.python-version }} python scripts/fetch_resources.py
+
+      # EstNLTK's upstream S3 (hpc.ut.ee) goes down periodically; keep the
+      # GH Release mirror as a fallback so an upstream outage doesn't red
+      # the build. Only runs if the step above left WordNet unusable.
+      - name: WordNet mirror fallback (only if upstream failed)
         run: |
-          set +e
-          echo "y" | uv run --python ${{ matrix.python-version }} python -c "from estnltk.wordnet import Wordnet; Wordnet()"
-          status=$?
           set -e
-          if [ $status -ne 0 ]; then
-            echo "Upstream WordNet download failed; falling back to GH Release mirror."
+          usable=$(uv run --python ${{ matrix.python-version }} python -c "
+          try:
+              from estnltk.wordnet import Wordnet
+              print('yes' if Wordnet()['kasutama'] else 'no')
+          except Exception:
+              print('no')
+          " 2>/dev/null | tail -1)
+          if [ "$usable" != "yes" ]; then
+            echo "WordNet unusable after setup; falling back to the GH Release mirror."
             WN_DIR=$(uv run --python ${{ matrix.python-version }} python -c "from estnltk.resource_utils import get_resources_dir; print(get_resources_dir())")
             mkdir -p "$WN_DIR/wordnet"
-            curl -fsSL --retry 3 --retry-delay 2 \
-              -o /tmp/wn.zip \
+            curl -fsSL --retry 3 --retry-delay 2 -o /tmp/wn.zip \
               "https://github.com/silly-geese/estonian-mcp/releases/download/v0.1.0-models/wordnet_2026-02-13.zip"
             unzip -q -o /tmp/wn.zip -d "$WN_DIR/wordnet/"
             rm /tmp/wn.zip
-            # sanity: confirm Wordnet() now loads from the unpacked tree
             uv run --python ${{ matrix.python-version }} python -c "from estnltk.wordnet import Wordnet; assert Wordnet()['kasutama'], 'wordnet still not loadable after mirror fallback'"
+          else
+            echo "WordNet OK from the documented setup step."
           fi
-
-      - name: Pre-download fastText-et-medium (used by find_related_words + check_compound_familiarity)
-        run: |
-          mkdir -p $HOME/.cache/estnltk-mcp
-          F="$HOME/.cache/estnltk-mcp/fasttext-et-medium"
-          curl -fsSL --retry 3 --retry-delay 2 -o "$F" \
-            "https://github.com/silly-geese/estonian-mcp/releases/download/v0.1.0-models/fasttext-et-medium"
-          echo "3690ee9983fc95740a61125fd58ed385  $F" | md5sum -c -
-          echo "ESTNLTK_MCP_FASTTEXT_PATH=$F" >> $GITHUB_ENV
 
       - name: Run tool smoke tests
         run: uv run --python ${{ matrix.python-version }} python tests/test_smoke.py
@@ -89,12 +93,6 @@ jobs:
       # is invoked with outbound sockets blocked.
       - name: Run no-outbound-network tests
         run: uv run --python ${{ matrix.python-version }} python tests/test_no_network.py
-
-      # The setup path a source install actually follows. Runs last so a
-      # break here is unambiguous, and proves the script is idempotent
-      # against resources CI already fetched by other means.
-      - name: Verify scripts/fetch_resources.py is idempotent
-        run: uv run --python ${{ matrix.python-version }} python scripts/fetch_resources.py
 
   # Proves the DOCUMENTED source-install path works, from a clean state.
   # The existing `smoke` job pre-fetches resources through bespoke steps and
@@ -123,16 +121,25 @@ jobs:
           mkdir -p /tmp/empty-nltk /tmp/empty-estnltk
           uv run --python 3.13 python - <<'EOF'
           import server
-          try:
-              server.synonyms("kohv")
-              raise SystemExit("expected synonyms to fail without WordNet")
-          except RuntimeError as e:
-              assert "fetch_resources.py" in str(e), e
-              print("synonyms fails with an actionable message, as intended")
-          r = server.check_term_consistency("Andmestik ja teadusandmestik.")
-          assert r["degraded"] is True, r
-          assert "osaline" in r["summary_estonian"], r["summary_estonian"]
-          print("check_term_consistency reports degraded, as intended")
+          # Every resource-dependent tool must fail with an ACTIONABLE
+          # message naming the setup script — never a raw NLTK LookupError
+          # telling the user to run nltk.download(), which is advice this
+          # server deliberately does not follow.
+          for call in (
+              lambda: server.synonyms("kohv"),
+              lambda: server.check_compounds("Kooli maja on suur."),
+              lambda: server.check_term_consistency("Andmestik ja teadusandmestik."),
+              lambda: server.find_related_words("kohv", 3),
+          ):
+              try:
+                  call()
+              except RuntimeError as e:
+                  assert "fetch_resources.py" in str(e), f"unhelpful message: {e}"
+              except Exception as e:
+                  raise SystemExit(f"expected an actionable RuntimeError, got {type(e).__name__}: {e}")
+              else:
+                  raise SystemExit("expected the tool to fail before setup")
+          print("all resource-dependent tools fail actionably before setup")
           EOF
 
       # The README's setup step, verbatim. No env overrides.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,67 @@ jobs:
       - name: Verify scripts/fetch_resources.py is idempotent
         run: uv run --python ${{ matrix.python-version }} python scripts/fetch_resources.py
 
+  # Proves the DOCUMENTED source-install path works, from a clean state.
+  # The existing `smoke` job pre-fetches resources through bespoke steps and
+  # exports ESTNLTK_MCP_FASTTEXT_PATH, which masks exactly the class of bug
+  # issues #37/#38 were about: it could stay green while a user following
+  # the README got a broken install. This job follows the README instead.
+  source-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.13
+
+      - name: uv sync (nothing else)
+        run: uv sync --frozen --python 3.13
+
+      # Isolate every resource search path so nothing pre-seeded on the
+      # runner can make this pass for the wrong reason.
+      - name: Confirm the tools are genuinely broken before setup
+        env:
+          NLTK_DATA: /tmp/empty-nltk
+          ESTNLTK_RESOURCES: /tmp/empty-estnltk
+        run: |
+          mkdir -p /tmp/empty-nltk /tmp/empty-estnltk
+          uv run --python 3.13 python - <<'EOF'
+          import server
+          try:
+              server.synonyms("kohv")
+              raise SystemExit("expected synonyms to fail without WordNet")
+          except RuntimeError as e:
+              assert "fetch_resources.py" in str(e), e
+              print("synonyms fails with an actionable message, as intended")
+          r = server.check_term_consistency("Andmestik ja teadusandmestik.")
+          assert r["degraded"] is True, r
+          assert "osaline" in r["summary_estonian"], r["summary_estonian"]
+          print("check_term_consistency reports degraded, as intended")
+          EOF
+
+      # The README's setup step, verbatim. No env overrides.
+      - name: Run the documented setup step
+        run: uv run --python 3.13 python scripts/fetch_resources.py
+
+      - name: The README's verify step, with no fastText override
+        run: uv run --python 3.13 python tests/test_smoke.py
+
+      - name: Resource-backed tools work with no env override
+        run: |
+          uv run --python 3.13 python - <<'EOF'
+          import server
+          assert server.synonyms("kohv")["synsets"], "synonyms empty"
+          assert server.find_related_words("kohv", 3)["matches"], "fastText empty"
+          assert server.check_compounds("Kooli maja on suur.")["issues"], "punkt_tab path broken"
+          r = server.check_term_consistency("Andmestik ja teadusandmestik.")
+          assert r["degraded"] is False, r
+          print("all resource-backed tools OK after the documented setup")
+          EOF
+
+      - name: Setup step is idempotent
+        run: uv run --python 3.13 python scripts/fetch_resources.py
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -106,8 +167,11 @@ jobs:
       # Config lives in ruff.toml and encodes this repo's actual
       # conventions, so a failure here means a real deviation rather than
       # a disagreement about style.
+      # Pinned: an unpinned `uvx ruff` resolves to latest at run time, so a
+      # future release adding rules under our selected prefixes would turn an
+      # unchanged codebase red with no commit to blame.
       - name: ruff
-        run: uvx ruff check . --output-format=github
+        run: uvx ruff@0.14.2 check . --output-format=github
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Run resource-availability tests (issues #37, #38)
         run: uv run --python ${{ matrix.python-version }} python tests/test_resources.py
 
+      # Enforces the PRIVACY.md promise instead of trusting it: every tool
+      # is invoked with outbound sockets blocked.
+      - name: Run no-outbound-network tests
+        run: uv run --python ${{ matrix.python-version }} python tests/test_no_network.py
+
       # The setup path a source install actually follows. Runs last so a
       # break here is unambiguous, and proves the script is idempotent
       # against resources CI already fetched by other means.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,29 @@ now asserts that rather than leaving it to luck.
 
 ### Changed
 
+- **The server now structurally refuses resource downloads.** Adversarial
+  review caught that the first version of this fix made things *worse*, not
+  better: `get_resource_paths()` consults EstNLTK's resource index and
+  re-fetches it over HTTPS whenever the local copy is more than two hours
+  old. So a healthy, long-running server made a periodic outbound call to
+  `raw.githubusercontent.com` on the next `synonyms` or
+  `check_term_consistency` — and when that call failed it reported an
+  *installed* WordNet as missing. `_wordnet_available()` now reads the
+  resources directory directly.
+
+  A second path was open in the same way: EstNLTK's sentence tokenizer
+  catches `LookupError` for NLTK's `punkt_tab` and calls
+  `nltk.downloader.download()`. The `sentences` layer is built by
+  `tag_layer(["morph_analysis"])`, so nearly every tool could reach it.
+  `_forbid_resource_downloads()` now pins the index timeout and replaces
+  NLTK's downloader with a refusal that names the setup script.
+- **`find_related_words` and `check_compound_familiarity` now find the
+  model a source install actually has.** `_embeddings()` defaulted to the
+  container path only, while `fetch_resources.py` writes to
+  `~/.cache/estnltk-mcp/`. Following the documented setup and then running
+  the documented verify step failed, because the script cannot export a
+  variable into the server process — and a JSON-configured MCP client
+  cannot run a shell `export` at all. The lookup now tries both.
 - **Dockerfile fetches `punkt_tab` explicitly and asserts it loads.** The
   image already worked, but by accident rather than by construction — a
   base-image change could have removed it silently and broken
@@ -64,6 +87,23 @@ now asserts that rather than leaving it to luck.
   `fetch_resources.py` to prove it is idempotent.
 - **README** leads the source-install path with the fetch step and explains
   why the server never downloads anything itself.
+- **`tests/test_no_network.py` enforces the privacy promise** rather than
+  documenting it: every tool runs with sockets and DNS blocked, and the
+  blocker *records* each attempt instead of only raising — the first
+  version raised, and the code under test caught the exception by design,
+  so it passed against a live violation. Covers the stale-index case
+  specifically, which is the production steady state.
+- **A `source-install` CI job follows the README verbatim** from a clean
+  state with every resource path isolated: it asserts the tools fail
+  *actionably* before setup, runs the documented command, then proves they
+  work with no environment override. The existing `smoke` job pre-fetches
+  resources and exports `ESTNLTK_MCP_FASTTEXT_PATH`, which is precisely why
+  it stayed green while a README-following user got a broken install.
+- **`scripts/fetch_resources.py` validates by use, not by existence.** Each
+  resource is checked by actually tokenising / querying / hashing it, so a
+  truncated or partially-extracted artifact is replaced rather than
+  accepted forever. punkt_tab extracts to a staging dir with zip-slip
+  protection and is swapped in only after it tokenises, with rollback.
 
 ## [0.5.2] — 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-08-23
+
+Fixes both issues reported by @Kivaste against 0.5.1. Neither affected the
+hosted server or the one-click image — verified by calling both tools on
+the live deployment before changing anything — so this is a source-install
+release. #37 asked whether the image was affected too; it is not, and CI
+now asserts that rather than leaving it to luck.
+
+### Fixed
+
+- **`check_term_consistency` reported a confident negative while running at
+  half strength** ([#38](https://github.com/silly-geese/estonian-mcp/issues/38)).
+  With Estonian WordNet missing it returned "Ebajärjekindlat terminikasutust
+  ei tuvastatud" — reads as a clean bill of health — while the
+  `shared-wordnet-synset` rule never ran. The only signal was a `rules_run`
+  flag you had to know to read. Now the degradation is stated in
+  `summary_estonian` itself, in Estonian, with the command that fixes it,
+  and a top-level `degraded: true` field. As the reporter put it: a crash is
+  honest, this was not.
+- **The server no longer attempts to DOWNLOAD a missing resource.** The old
+  code called `Wordnet()` and caught the fallout, so on a machine without
+  the resource EstNLTK would try to fetch it — breaching the "no outbound
+  HTTP calls" promise in PRIVACY.md — and print its confirmation prompt to
+  stdout, which under stdio transport *is* the MCP protocol channel. A new
+  `_wordnet_available()` checks the filesystem first via
+  `get_resource_paths(download_missing=False)`, so neither can happen.
+  `synonyms` now raises a clear, actionable error instead.
+
+### Added
+
+- **`scripts/fetch_resources.py`** — the missing setup step for source
+  installs ([#37](https://github.com/silly-geese/estonian-mcp/issues/37)).
+  Fetches NLTK `punkt_tab`, Estonian WordNet and the fastText model, none of
+  which can come from `uv.lock` because they are data, not Python
+  distributions. Sets `SSL_CERT_FILE` from `certifi` first — uv-provisioned
+  interpreters ship without a CA trust store, so the documented
+  `nltk.download()` route fails with `CERTIFICATE_VERIFY_FAILED`; credit to
+  the reporter for diagnosing that. fastText is checksum-verified and moved
+  into place only after verification, so an interrupted download cannot
+  masquerade as a good model. Idempotent.
+
+  It is a script, not lazy auto-download, on purpose: the network access is
+  yours at setup time, never the server's at request time.
+
+### Changed
+
+- **Dockerfile fetches `punkt_tab` explicitly and asserts it loads.** The
+  image already worked, but by accident rather than by construction — a
+  base-image change could have removed it silently and broken
+  `check_compounds` for every one-click user.
+- **CI covers both issues.** The container test now calls `check_compounds`
+  and asserts `check_term_consistency` comes back `degraded: false`, so the
+  image can never regress into serving confident-but-partial answers. The
+  smoke matrix runs the new `tests/test_resources.py` and executes
+  `fetch_resources.py` to prove it is idempotent.
+- **README** leads the source-install path with the fetch step and explains
+  why the server never downloads anything itself.
+
 ## [0.5.2] — 2026-08-23
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,23 @@ RUN set +e; \
       /opt/venv/bin/python -c "from estnltk.wordnet import Wordnet; assert Wordnet()['kasutama'], 'wordnet still not loadable after mirror fallback'" ; \
     fi
 
+# NLTK punkt_tab — the sentence tokenizer EstNLTK's `sentences` layer
+# uses. It is NLTK corpus data, not a Python distribution, so `uv sync`
+# cannot install it and it is absent from uv.lock. The image happened to
+# work without an explicit fetch, but "works by accident" is not a
+# property you want in a published image: a base-image or dependency
+# change could remove it silently and break check_compounds /
+# check_term_consistency for every one-click user. Fetch it explicitly
+# and assert it loads, so the build fails loudly instead.
+# Reported as https://github.com/silly-geese/estonian-mcp/issues/37.
+RUN /opt/venv/bin/python -c "import nltk; nltk.download('punkt_tab', quiet=False)" \
+ && /opt/venv/bin/python -c "import nltk; nltk.data.find('tokenizers/punkt_tab/estonian/')" \
+ && /opt/venv/bin/python -c "\
+from estnltk import Text; \
+t = Text('Kooli maja on suur. Teine lause siin.'); \
+t.tag_layer(['sentences', 'morph_analysis']); \
+assert len(list(t.sentences)) == 2, 'sentence layer broken after punkt_tab fetch'"
+
 # Estonian fastText word embeddings, compressed to ~33 MB with a 100K
 # vocabulary. Used by find_related_words + check_compound_familiarity.
 # Built locally from Facebook's cc.et.300.bin (Grave et al. 2018,

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,14 @@ RUN set +e; \
 # check_term_consistency for every one-click user. Fetch it explicitly
 # and assert it loads, so the build fails loudly instead.
 # Reported as https://github.com/silly-geese/estonian-mcp/issues/37.
-RUN /opt/venv/bin/python -c "import nltk; nltk.download('punkt_tab', quiet=False)" \
+# download_dir is NOT optional here. This is a multi-stage build and the
+# runtime stage copies only /opt/venv, /opt/models and /app. NLTK's default
+# target for root is /root/nltk_data, which is never copied — the build
+# would pass every assertion below and still ship an image without the
+# data. /opt/venv/nltk_data rides along with the venv and is on NLTK's
+# default search path at runtime (it derives paths from sys.prefix).
+RUN /opt/venv/bin/python -c "import nltk; nltk.download('punkt_tab', download_dir='/opt/venv/nltk_data', quiet=False)" \
+ && test -d /opt/venv/nltk_data/tokenizers/punkt_tab/estonian \
  && /opt/venv/bin/python -c "import nltk; nltk.data.find('tokenizers/punkt_tab/estonian/')" \
  && /opt/venv/bin/python -c "\
 from estnltk import Text; \

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -35,12 +35,20 @@ account to create.
   shipped to a log aggregator, never observable by us.
 - **No analytics or telemetry.** The server makes no outbound HTTP
   calls and reports no usage to any third party.
+- **No runtime resource downloads either.** The server never fetches a
+  missing resource to fill a gap it notices — not on import, not during
+  a tool call. Availability is checked against the local filesystem, and
+  a tool whose resource is absent says so (an actionable error, or a
+  `degraded: true` result) rather than reaching for the network. On a
+  source install you fetch resources yourself, once, by running
+  `scripts/fetch_resources.py`; that network access is yours at setup
+  time, never the server's while serving.
 - **No third-party processors.** All analysis runs locally inside the
   server container. We do not call OpenAI, Anthropic, Google, or any
   other inference provider. EstNLTK and Vabamorf models are bundled
-  into the Docker image; WordNet and fastText resources are
-  pre-downloaded at image-build time and served from the container
-  filesystem.
+  into the Docker image; NLTK `punkt_tab`, WordNet and fastText
+  resources are pre-downloaded at image-build time and served from the
+  container filesystem.
 - **No cookies, no tracking, no fingerprinting.**
 - **No training.** Your inputs are not used to train any model. The
   fastText, WordNet, and morphological models bundled with the
@@ -99,4 +107,4 @@ This policy may be updated; substantive changes will appear in git
 history. The latest version is always at
 `https://github.com/silly-geese/estonian-mcp/blob/master/PRIVACY.md`.
 
-Last updated: 2026-05-10.
+Last updated: 2026-08-23.

--- a/README.md
+++ b/README.md
@@ -424,16 +424,24 @@ Terms of service for the hosted endpoint: [TERMS.md](TERMS.md).
 
 ## Notes
 
-- Most EstNLTK models (morph, NER, spell-check) ship inside the
-  wheel, no runtime downloads.
-- WordNet is a separate ~26 MB resource (used by `synonyms`); the
-  Docker image pre-downloads it at build time so the first call
-  doesn't pause to fetch it.
+- **The server never downloads anything at runtime.** Not on import, not
+  on a tool call, not to fill a gap it notices. That's the
+  [privacy promise](PRIVACY.md). Resources are fetched at Docker build
+  time, or by you running `scripts/fetch_resources.py` on a source
+  install. If a resource is missing, tools say so — `synonyms` raises an
+  actionable error, and `check_term_consistency` returns
+  `degraded: true` with the reason in its Estonian summary rather than a
+  confident-looking partial answer.
+- Most EstNLTK models (morph, NER, spell-check) ship inside the wheel.
+  Three things don't, because they're *data*, not Python distributions,
+  so `uv.lock` can't carry them: NLTK's `punkt_tab` tokenizer, WordNet,
+  and the fastText model.
+- WordNet is a separate ~26 MB resource (used by `synonyms` and one of
+  `check_term_consistency`'s two rules).
 - The fastText model used by `find_related_words` and
   `check_compound_familiarity` is a ~33 MB compressed resource with a
   100K-word vocabulary (built locally from Facebook's cc.et.300 via
-  compress-fasttext, CC-BY-SA-3.0; see [NOTICE](NOTICE)); pre-downloaded
-  at image-build time.
+  compress-fasttext, CC-BY-SA-3.0; see [NOTICE](NOTICE)).
 - Heavy neural taggers (`estnltk_neural`, BERT-based NER) are
   intentionally not pulled in; this server stays lean and fast.
 - First call after server start incurs a one-time tag-layer load

--- a/README.md
+++ b/README.md
@@ -300,8 +300,22 @@ EstNLTK requires Python 3.10–3.13.
 git clone https://github.com/silly-geese/estonian-mcp.git
 cd estonian-mcp
 uv sync
-uv run python tests/test_smoke.py     # verify
+uv run python scripts/fetch_resources.py   # required, see below
+uv run python tests/test_smoke.py          # verify
 ```
+
+**Don't skip the `fetch_resources.py` step.** `uv sync` installs Python
+packages, but three of the things the server needs are *data*, not Python
+distributions, so they can't live in `uv.lock`: NLTK's `punkt_tab`
+tokenizer, Estonian WordNet (~26 MB), and the fastText embeddings
+(~33 MB). Without them `check_compounds` and `check_term_consistency`
+raise, `synonyms` refuses to run, and `check_term_consistency` reports
+`degraded: true`. The script is idempotent, so re-running it is free.
+
+The server **never downloads anything itself** — not at import, not on a
+tool call. That's the [privacy promise](PRIVACY.md): no outbound HTTP from
+the running process. Fetching is a separate step *you* run knowingly, and
+the Docker image does the equivalent at build time.
 
 Then wire it into your client.
 
@@ -436,16 +450,16 @@ sharpen the linguistic rules. Here's how to get started:
 2. **Set up** the environment (Python 3.10–3.13):
    ```sh
    uv sync
-   # the fastText-backed tools need the embedding model for tests:
-   curl -fsSL -o ~/.cache/estnltk-mcp/fasttext-et-medium --create-dirs \
-     "https://github.com/silly-geese/estonian-mcp/releases/download/v0.1.0-models/fasttext-et-medium"
+   # punkt_tab + WordNet + fastText — none can come from uv.lock:
+   uv run python scripts/fetch_resources.py
    export ESTNLTK_MCP_FASTTEXT_PATH=~/.cache/estnltk-mcp/fasttext-et-medium
    ```
 3. **Create a feature branch** (`git checkout -b feature/my-feature`).
 4. **Run the tests**, both must pass:
    ```sh
-   uv run python tests/test_smoke.py   # tool behaviour
-   uv run python tests/test_http.py    # transport, auth, /metrics
+   uv run python tests/test_smoke.py       # tool behaviour
+   uv run python tests/test_http.py        # transport, auth, /metrics
+   uv run python tests/test_resources.py   # resource-availability handling
    ```
 5. **Commit** and open a pull request against `master`. CI (smoke on
    Python 3.11 + 3.13, plus a Docker build/boot check) must be green

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.2"
+version = "0.5.3"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,34 @@
+# Lint config for estonian-mcp.
+#
+# Encodes the conventions this codebase already follows, so `ruff check`
+# is a real gate rather than a wall of noise. Two deliberate carve-outs:
+#
+#   BLE001 (blind `except Exception`) — used throughout on purpose. A
+#   resource load, a model file, or an EstNLTK call can fail in many ways,
+#   and the correct behaviour is almost always to degrade and report rather
+#   than to propagate. Narrow excepts here would be a list of every
+#   dependency's internal exception types, which rots.
+#
+#   E402 in tests/ — every test file inserts the repo root on sys.path
+#   before `import server`, which necessarily puts an import after code.
+line-length = 100
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "W", "I", "UP", "B", "C4", "RUF"]
+ignore = [
+    "E501",    # long lines: prose in docstrings and Estonian strings
+    # This codebase is full of Estonian prose and typographic punctuation
+    # (en dashes, curly quotes, õ/ä/ö/ü/š/ž). "Ambiguous character" is the
+    # correct character here, not a mistake.
+    "RUF001", "RUF002", "RUF003",
+]
+
+[lint.per-file-ignores]
+# Test files are scripts: sys.path setup precedes imports by necessity,
+# and module-level assertions/imports mid-file are the established style.
+# `# noqa: E402` is kept explicit at each site rather than blanket-ignored,
+# so the sys.path-before-import trick stays visible to the reader.
+"tests/*" = ["F401"]
+# One-off data-prep scripts, not part of the served surface.
+"scripts/eval_*.py" = ["E402"]

--- a/scripts/eval_coverage.py
+++ b/scripts/eval_coverage.py
@@ -22,10 +22,11 @@ not capability scores. Run from repo root (sample size as argv[1]):
 from __future__ import annotations
 
 import sys
+
 from datasets import load_dataset
 
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent))
-import server  # noqa: E402
+import server
 
 
 def grammar_detection_recall(n: int) -> None:

--- a/scripts/eval_inflection.py
+++ b/scripts/eval_inflection.py
@@ -36,7 +36,7 @@ from estnltk.vabamorf.morf import Vabamorf
 # Reuse the MCP's own indeclinability knowledge so the score reflects a
 # real capability the server has, not an eval-only special case.
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent))
-from server import _is_indeclinable_attr  # noqa: E402
+from server import _is_indeclinable_attr
 
 # Estonian number / case names (as used in inflection_et) → Vabamorf
 # form codes. The illative maps to BOTH the long (ill) and the short /

--- a/scripts/fetch_resources.py
+++ b/scripts/fetch_resources.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Fetch the NLP resources estonian-mcp needs, for SOURCE installs.
+
+    uv run python scripts/fetch_resources.py
+
+`uv sync` installs Python distributions. It cannot install NLTK corpus data
+or EstNLTK resources, because those are not Python distributions and are not
+in `uv.lock`. So a fresh `git clone && uv sync` leaves three gaps:
+
+  * NLTK `punkt_tab` — the sentence tokenizer EstNLTK's `sentences` layer
+    uses. Without it, tools that tag that layer raise `LookupError`.
+  * Estonian WordNet (~26 MB) — needed by `synonyms`, and by the
+    `shared-wordnet-synset` rule in `check_term_consistency`.
+  * fastText embeddings (~33 MB) — needed by `find_related_words` and
+    `check_compound_familiarity`. Served from this project's own GitHub
+    release, the same artifact the Dockerfile uses, so no new third party
+    is involved.
+
+WHY THIS IS A SCRIPT AND NOT LAZY AUTO-DOWNLOAD
+-----------------------------------------------
+PRIVACY.md promises the running server makes **no outbound HTTP calls** and
+uses no third-party processors. Fetching resources on demand from inside a
+tool call would break that promise, and under stdio transport the download
+prompt would be written to stdout — which is the MCP protocol channel — and
+corrupt the stream.
+
+So fetching is deliberately a separate, explicit step that you run: the
+network access is yours, knowingly, at setup time, not the server's at
+request time. The Docker image does the same thing at BUILD time; nothing
+is ever fetched while serving.
+
+CA TRUST STORE
+--------------
+uv-provisioned interpreters ship without a CA trust store, so NLTK's and
+EstNLTK's downloads fail with CERTIFICATE_VERIFY_FAILED. `certifi` is
+already present as a transitive dependency, so we point SSL_CERT_FILE at it
+before importing anything that downloads. This must happen before those
+imports, which is why it is at the top of main() rather than inline.
+
+Safe to re-run: every fetch is skipped when the resource is already
+present, so this is idempotent.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+# NLTK's own mirror. Pinned to the gh-pages package path NLTK itself serves.
+PUNKT_TAB_URL = (
+    "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/"
+    "packages/tokenizers/punkt_tab.zip"
+)
+
+# Same artifact the Dockerfile pulls, from this project's own release, so
+# a source install and the image end up on identical bytes.
+FASTTEXT_URL = (
+    "https://github.com/silly-geese/estonian-mcp/releases/download/"
+    "v0.1.0-models/fasttext-et-medium"
+)
+# Matches the checksum the CI workflow verifies for the same file.
+FASTTEXT_MD5 = "3690ee9983fc95740a61125fd58ed385"
+
+
+def _fasttext_target() -> Path:
+    """Where the server looks for the model (env override wins)."""
+    env = os.environ.get("ESTNLTK_MCP_FASTTEXT_PATH")
+    if env:
+        return Path(env)
+    return Path.home() / ".cache" / "estnltk-mcp" / "fasttext-et-medium"
+
+
+def fetch_fasttext() -> bool:
+    """Download the compressed fastText model, verifying its checksum."""
+    import hashlib
+
+    target = _fasttext_target()
+    if target.exists():
+        print(f"  fasttext: already present at {target}, skipping")
+        return True
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    print(f"  fasttext: downloading (~33 MB) -> {target}")
+    tmp = target.with_suffix(".partial")
+    try:
+        with urllib.request.urlopen(FASTTEXT_URL, timeout=300) as r:
+            tmp.write_bytes(r.read())
+    except Exception as e:
+        tmp.unlink(missing_ok=True)
+        print(f"  fasttext: FAILED ({type(e).__name__}: {e})")
+        return False
+
+    digest = hashlib.md5(tmp.read_bytes()).hexdigest()
+    if digest != FASTTEXT_MD5:
+        tmp.unlink(missing_ok=True)
+        print(f"  fasttext: CHECKSUM MISMATCH (got {digest}, want {FASTTEXT_MD5})")
+        return False
+    # Only move into place once verified, so an interrupted or corrupted
+    # download can never masquerade as a good model.
+    tmp.replace(target)
+    print("  fasttext: OK")
+    if not os.environ.get("ESTNLTK_MCP_FASTTEXT_PATH"):
+        print(f"           set ESTNLTK_MCP_FASTTEXT_PATH={target} for the server")
+    return True
+
+
+def _use_certifi_trust_store() -> str | None:
+    """Point SSL_CERT_FILE at certifi's bundle if it is not already set.
+
+    Returns the path used, or None if certifi is unavailable (in which case
+    we leave the environment alone and let the download fail loudly rather
+    than silently disabling verification — we never set a permissive TLS
+    mode)."""
+    if os.environ.get("SSL_CERT_FILE"):
+        return os.environ["SSL_CERT_FILE"]
+    try:
+        import certifi
+    except ImportError:
+        return None
+    path = certifi.where()
+    os.environ["SSL_CERT_FILE"] = path
+    os.environ.setdefault("REQUESTS_CA_BUNDLE", path)
+    return path
+
+
+def fetch_punkt_tab() -> bool:
+    """Download NLTK punkt_tab into the first writable nltk_data dir."""
+    import nltk
+
+    try:
+        nltk.data.find("tokenizers/punkt_tab/estonian/")
+        print("  punkt_tab: already present, skipping")
+        return True
+    except LookupError:
+        pass
+
+    # Prefer a venv-local dir so the fetch does not pollute the user's home
+    # and stays with the checkout it belongs to.
+    target = Path(sys.prefix) / "nltk_data"
+    tokenizers = target / "tokenizers"
+    tokenizers.mkdir(parents=True, exist_ok=True)
+    if str(target) not in nltk.data.path:
+        nltk.data.path.insert(0, str(target))
+
+    print(f"  punkt_tab: downloading -> {tokenizers}")
+    zip_path = tokenizers / "punkt_tab.zip"
+    try:
+        with urllib.request.urlopen(PUNKT_TAB_URL, timeout=60) as r:
+            zip_path.write_bytes(r.read())
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(tokenizers)
+        zip_path.unlink(missing_ok=True)
+    except Exception as e:
+        print(f"  punkt_tab: FAILED ({type(e).__name__}: {e})")
+        return False
+
+    try:
+        nltk.data.find("tokenizers/punkt_tab/estonian/")
+    except LookupError:
+        print("  punkt_tab: downloaded but Estonian model still not found")
+        return False
+    print("  punkt_tab: OK")
+    return True
+
+
+def fetch_wordnet() -> bool:
+    """Download Estonian WordNet via EstNLTK's own resource downloader."""
+    from estnltk.downloader import download, get_resource_paths
+
+    if get_resource_paths("wordnet", only_latest=True, download_missing=False):
+        print("  wordnet: already present, skipping")
+        return True
+
+    print("  wordnet: downloading (~26 MB)")
+    try:
+        download("wordnet")
+    except Exception as e:
+        print(f"  wordnet: FAILED ({type(e).__name__}: {e})")
+        return False
+
+    if not get_resource_paths("wordnet", only_latest=True, download_missing=False):
+        print("  wordnet: download reported success but resource is not found")
+        return False
+    print("  wordnet: OK")
+    return True
+
+
+def main() -> int:
+    trust = _use_certifi_trust_store()
+    print("estonian-mcp resource fetch")
+    if trust:
+        print(f"  TLS trust store: {trust}")
+    else:
+        print("  TLS trust store: certifi not found; using system default")
+
+    ok_punkt = fetch_punkt_tab()
+    ok_wordnet = fetch_wordnet()
+    ok_fasttext = fetch_fasttext()
+
+    print()
+    if ok_punkt and ok_wordnet and ok_fasttext:
+        print("All resources present. estonian-mcp will run at full strength.")
+        return 0
+    # Partial success is still useful — say precisely what is degraded so the
+    # operator knows which tools are affected rather than guessing.
+    if not ok_punkt:
+        print("punkt_tab missing: tools tagging the `sentences` layer will raise.")
+    if not ok_wordnet:
+        print(
+            "wordnet missing: `synonyms` will raise, and "
+            "`check_term_consistency` runs with only its compound-head rule "
+            "(its output reports degraded: true)."
+        )
+    if not ok_fasttext:
+        print(
+            "fasttext missing: `find_related_words` and "
+            "`check_compound_familiarity` will raise."
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_resources.py
+++ b/scripts/fetch_resources.py
@@ -83,7 +83,10 @@ def fetch_fasttext() -> bool:
 
     target.parent.mkdir(parents=True, exist_ok=True)
     print(f"  fasttext: downloading (~33 MB) -> {target}")
-    tmp = target.with_suffix(".partial")
+    # Append rather than with_suffix(): with_suffix REPLACES an existing
+    # suffix, so an operator-supplied ESTNLTK_MCP_FASTTEXT_PATH ending in
+    # e.g. `.bin` would produce a temp name derived from a different stem.
+    tmp = target.parent / (target.name + ".partial")
     try:
         with urllib.request.urlopen(FASTTEXT_URL, timeout=300) as r:
             tmp.write_bytes(r.read())

--- a/scripts/fetch_resources.py
+++ b/scripts/fetch_resources.py
@@ -42,19 +42,10 @@ present, so this is idempotent.
 """
 from __future__ import annotations
 
-import io
 import os
-import shutil
 import sys
 import urllib.request
-import zipfile
 from pathlib import Path
-
-# NLTK's own mirror. Pinned to the gh-pages package path NLTK itself serves.
-PUNKT_TAB_URL = (
-    "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/"
-    "packages/tokenizers/punkt_tab.zip"
-)
 
 # Same artifact the Dockerfile pulls, from this project's own release, so
 # a source install and the image end up on identical bytes.
@@ -156,21 +147,6 @@ def _use_certifi_trust_store() -> str | None:
     return path
 
 
-def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
-    """Extract with zip-slip protection.
-
-    `ZipFile.extractall` will happily follow `../` in a member name and
-    write outside `dest`. This is a downloaded archive, so resolve every
-    member and refuse anything that escapes the destination.
-    """
-    dest_root = dest.resolve()
-    for member in zf.infolist():
-        out = (dest_root / member.filename).resolve()
-        if not out.is_relative_to(dest_root):
-            raise ValueError(f"unsafe path in archive: {member.filename!r}")
-    zf.extractall(dest)
-
-
 def _punkt_usable() -> bool:
     """Validate by USE: the data is only good if it actually tokenises.
 
@@ -190,67 +166,63 @@ def _punkt_usable() -> bool:
 
 
 def fetch_punkt_tab() -> bool:
-    """Download NLTK punkt_tab, extracting atomically after validation."""
+    """Download NLTK punkt_tab via NLTK's own downloader, then validate.
+
+    Uses `nltk.download` rather than fetching the zip by hand, deliberately.
+    NLTK publishes size + sha256 for each package in an `index.xml` on the
+    same branch as the data, fetched at download time, and installs via a
+    temp file + `os.replace`. That check cannot go stale, whereas a checksum
+    hardcoded here would break every user the moment NLTK republishes the
+    archive in place — which it does: `nltk_data` carries no tags or
+    releases, and punkt_tab has already been rewritten under the same URL
+    (2024-07-09, then 2025-02-17 to add Malayalam). Pin what you control or
+    what is immutable; verify dynamically what rolls.
+
+    `download_dir` is not optional. NLTK's default picks the first existing
+    writable dir on `nltk.data.path`, which is `~/nltk_data` — that
+    pollutes the user's home and detaches the data from the checkout it
+    belongs to. `<sys.prefix>/nltk_data` is on NLTK's default search path,
+    so the server finds it with no configuration.
+    """
+    import socket
+
     import nltk
 
     if _punkt_usable():
         print("  punkt_tab: already present and usable, skipping")
         return True
 
-    # Venv-local, so the fetch stays with the checkout it belongs to rather
-    # than polluting the user's home. <sys.prefix>/nltk_data is on NLTK's
-    # default search path.
     target = Path(sys.prefix) / "nltk_data"
-    tokenizers = target / "tokenizers"
     try:
-        tokenizers.mkdir(parents=True, exist_ok=True)
+        target.mkdir(parents=True, exist_ok=True)
     except OSError as e:
-        print(f"  punkt_tab: FAILED (cannot create {tokenizers}: {e})")
+        print(f"  punkt_tab: FAILED (cannot create {target}: {e})")
         print("             is sys.prefix writable? run inside the venv (uv run ...)")
         return False
     if str(target) not in nltk.data.path:
         nltk.data.path.insert(0, str(target))
 
-    print(f"  punkt_tab: downloading -> {tokenizers}")
-    # Extract into a staging dir first, validate, then swap into place, so a
-    # failure part-way through can never leave a half-installed tree that
-    # later runs mistake for a good one.
-    staging = tokenizers / ".punkt_tab.staging"
-    final = tokenizers / "punkt_tab"
-    if staging.exists():
-        shutil.rmtree(staging, ignore_errors=True)
+    print(f"  punkt_tab: downloading -> {target}")
+    # NLTK's urlopen carries no timeout of its own.
+    socket.setdefaulttimeout(120)
     try:
-        with urllib.request.urlopen(PUNKT_TAB_URL, timeout=120) as r:
-            payload = r.read()
-        staging.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(io.BytesIO(payload)) as zf:
-            _safe_extract(zf, staging)
+        ok = nltk.download("punkt_tab", download_dir=str(target), quiet=True)
     except Exception as e:
-        shutil.rmtree(staging, ignore_errors=True)
         print(f"  punkt_tab: FAILED ({type(e).__name__}: {e})")
         return False
+    finally:
+        socket.setdefaulttimeout(None)
 
-    extracted = staging / "punkt_tab"
-    if not (extracted / "estonian").is_dir():
-        shutil.rmtree(staging, ignore_errors=True)
-        print("  punkt_tab: archive did not contain an Estonian model")
+    if not ok:
+        print("  punkt_tab: FAILED (nltk downloader reported an error)")
         return False
 
-    backup = tokenizers / ".punkt_tab.previous"
-    shutil.rmtree(backup, ignore_errors=True)
-    if final.exists():
-        final.rename(backup)
-    extracted.rename(final)
-    shutil.rmtree(staging, ignore_errors=True)
-
+    # Validate by use. The checksum proves we received upstream's bytes;
+    # this proves those bytes actually tokenise Estonian — a class of
+    # failure no checksum can catch.
     if not _punkt_usable():
-        # Roll back rather than leave the checkout worse than we found it.
-        shutil.rmtree(final, ignore_errors=True)
-        if backup.exists():
-            backup.rename(final)
-        print("  punkt_tab: downloaded data does not tokenise; rolled back")
+        print("  punkt_tab: downloaded but does not tokenise Estonian")
         return False
-    shutil.rmtree(backup, ignore_errors=True)
     print("  punkt_tab: OK")
     return True
 
@@ -258,7 +230,7 @@ def fetch_punkt_tab() -> bool:
 def _wordnet_usable() -> bool:
     """Validate by USE. An interrupted extraction can leave the version
     directory in place with an incomplete set of sqlite files, which an
-    index/exists check would accept forever."""
+    index or exists check would accept forever."""
     try:
         from estnltk.wordnet import Wordnet
         return bool(Wordnet()["kasutama"])

--- a/scripts/fetch_resources.py
+++ b/scripts/fetch_resources.py
@@ -42,7 +42,9 @@ present, so this is idempotent.
 """
 from __future__ import annotations
 
+import io
 import os
+import shutil
 import sys
 import urllib.request
 import zipfile
@@ -72,16 +74,42 @@ def _fasttext_target() -> Path:
     return Path.home() / ".cache" / "estnltk-mcp" / "fasttext-et-medium"
 
 
+def _md5(path: Path) -> str:
+    """Streaming MD5. `usedforsecurity=False` because this guards against
+    truncation and corruption over TLS from our own release asset, not
+    against a chosen-prefix attacker — and without it this raises on
+    FIPS-enabled builds (RHEL/UBI)."""
+    import hashlib
+
+    try:
+        h = hashlib.md5(usedforsecurity=False)
+    except TypeError:      # Python < 3.9 signature
+        h = hashlib.md5()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def fetch_fasttext() -> bool:
     """Download the compressed fastText model, verifying its checksum."""
-    import hashlib
 
     target = _fasttext_target()
     if target.exists():
-        print(f"  fasttext: already present at {target}, skipping")
-        return True
+        # "Exists" is not "good". A truncated leftover from an interrupted
+        # run would otherwise be accepted forever, and the server then fails
+        # to load it with an opaque error. Hashing 33 MB costs ~0.1 s.
+        if _md5(target) == FASTTEXT_MD5:
+            print(f"  fasttext: already present at {target}, skipping")
+            return True
+        print(f"  fasttext: existing file at {target} is corrupt, re-downloading")
+        target.unlink()
 
-    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        print(f"  fasttext: FAILED (cannot create {target.parent}: {e})")
+        return False
     print(f"  fasttext: downloading (~33 MB) -> {target}")
     # Append rather than with_suffix(): with_suffix REPLACES an existing
     # suffix, so an operator-supplied ESTNLTK_MCP_FASTTEXT_PATH ending in
@@ -95,7 +123,7 @@ def fetch_fasttext() -> bool:
         print(f"  fasttext: FAILED ({type(e).__name__}: {e})")
         return False
 
-    digest = hashlib.md5(tmp.read_bytes()).hexdigest()
+    digest = _md5(tmp)
     if digest != FASTTEXT_MD5:
         tmp.unlink(missing_ok=True)
         print(f"  fasttext: CHECKSUM MISMATCH (got {digest}, want {FASTTEXT_MD5})")
@@ -128,63 +156,132 @@ def _use_certifi_trust_store() -> str | None:
     return path
 
 
+def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract with zip-slip protection.
+
+    `ZipFile.extractall` will happily follow `../` in a member name and
+    write outside `dest`. This is a downloaded archive, so resolve every
+    member and refuse anything that escapes the destination.
+    """
+    dest_root = dest.resolve()
+    for member in zf.infolist():
+        out = (dest_root / member.filename).resolve()
+        if not out.is_relative_to(dest_root):
+            raise ValueError(f"unsafe path in archive: {member.filename!r}")
+    zf.extractall(dest)
+
+
+def _punkt_usable() -> bool:
+    """Validate by USE: the data is only good if it actually tokenises.
+
+    A directory-exists check accepts a partially-extracted tree — the zip
+    can fail after creating `punkt_tab/estonian/` but before writing all
+    its tables — and that partial state would then be skipped as
+    "already present" on every subsequent run.
+    """
+    try:
+        import nltk
+        nltk.data.find("tokenizers/punkt_tab/estonian/")
+        from nltk.tokenize.punkt import PunktTokenizer
+        tok = PunktTokenizer(lang="estonian")
+        return len(tok.tokenize("Kooli maja on suur. Teine lause siin.")) == 2
+    except Exception:
+        return False
+
+
 def fetch_punkt_tab() -> bool:
-    """Download NLTK punkt_tab into the first writable nltk_data dir."""
+    """Download NLTK punkt_tab, extracting atomically after validation."""
     import nltk
 
-    try:
-        nltk.data.find("tokenizers/punkt_tab/estonian/")
-        print("  punkt_tab: already present, skipping")
+    if _punkt_usable():
+        print("  punkt_tab: already present and usable, skipping")
         return True
-    except LookupError:
-        pass
 
-    # Prefer a venv-local dir so the fetch does not pollute the user's home
-    # and stays with the checkout it belongs to.
+    # Venv-local, so the fetch stays with the checkout it belongs to rather
+    # than polluting the user's home. <sys.prefix>/nltk_data is on NLTK's
+    # default search path.
     target = Path(sys.prefix) / "nltk_data"
     tokenizers = target / "tokenizers"
-    tokenizers.mkdir(parents=True, exist_ok=True)
+    try:
+        tokenizers.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        print(f"  punkt_tab: FAILED (cannot create {tokenizers}: {e})")
+        print("             is sys.prefix writable? run inside the venv (uv run ...)")
+        return False
     if str(target) not in nltk.data.path:
         nltk.data.path.insert(0, str(target))
 
     print(f"  punkt_tab: downloading -> {tokenizers}")
-    zip_path = tokenizers / "punkt_tab.zip"
+    # Extract into a staging dir first, validate, then swap into place, so a
+    # failure part-way through can never leave a half-installed tree that
+    # later runs mistake for a good one.
+    staging = tokenizers / ".punkt_tab.staging"
+    final = tokenizers / "punkt_tab"
+    if staging.exists():
+        shutil.rmtree(staging, ignore_errors=True)
     try:
-        with urllib.request.urlopen(PUNKT_TAB_URL, timeout=60) as r:
-            zip_path.write_bytes(r.read())
-        with zipfile.ZipFile(zip_path) as zf:
-            zf.extractall(tokenizers)
-        zip_path.unlink(missing_ok=True)
+        with urllib.request.urlopen(PUNKT_TAB_URL, timeout=120) as r:
+            payload = r.read()
+        staging.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+            _safe_extract(zf, staging)
     except Exception as e:
+        shutil.rmtree(staging, ignore_errors=True)
         print(f"  punkt_tab: FAILED ({type(e).__name__}: {e})")
         return False
 
-    try:
-        nltk.data.find("tokenizers/punkt_tab/estonian/")
-    except LookupError:
-        print("  punkt_tab: downloaded but Estonian model still not found")
+    extracted = staging / "punkt_tab"
+    if not (extracted / "estonian").is_dir():
+        shutil.rmtree(staging, ignore_errors=True)
+        print("  punkt_tab: archive did not contain an Estonian model")
         return False
+
+    backup = tokenizers / ".punkt_tab.previous"
+    shutil.rmtree(backup, ignore_errors=True)
+    if final.exists():
+        final.rename(backup)
+    extracted.rename(final)
+    shutil.rmtree(staging, ignore_errors=True)
+
+    if not _punkt_usable():
+        # Roll back rather than leave the checkout worse than we found it.
+        shutil.rmtree(final, ignore_errors=True)
+        if backup.exists():
+            backup.rename(final)
+        print("  punkt_tab: downloaded data does not tokenise; rolled back")
+        return False
+    shutil.rmtree(backup, ignore_errors=True)
     print("  punkt_tab: OK")
     return True
 
 
+def _wordnet_usable() -> bool:
+    """Validate by USE. An interrupted extraction can leave the version
+    directory in place with an incomplete set of sqlite files, which an
+    index/exists check would accept forever."""
+    try:
+        from estnltk.wordnet import Wordnet
+        return bool(Wordnet()["kasutama"])
+    except Exception:
+        return False
+
+
 def fetch_wordnet() -> bool:
     """Download Estonian WordNet via EstNLTK's own resource downloader."""
-    from estnltk.downloader import download, get_resource_paths
-
-    if get_resource_paths("wordnet", only_latest=True, download_missing=False):
-        print("  wordnet: already present, skipping")
+    if _wordnet_usable():
+        print("  wordnet: already present and usable, skipping")
         return True
 
     print("  wordnet: downloading (~26 MB)")
     try:
+        from estnltk.downloader import download
         download("wordnet")
     except Exception as e:
         print(f"  wordnet: FAILED ({type(e).__name__}: {e})")
         return False
 
-    if not get_resource_paths("wordnet", only_latest=True, download_missing=False):
-        print("  wordnet: download reported success but resource is not found")
+    if not _wordnet_usable():
+        print("  wordnet: download reported success but the data does not load")
         return False
     print("  wordnet: OK")
     return True

--- a/server.py
+++ b/server.py
@@ -216,13 +216,21 @@ def _vabamorf():
     return Vabamorf.instance()
 
 
-@lru_cache(maxsize=1)
 def _wordnet_available() -> bool:
     """True if Estonian WordNet is already on disk, WITHOUT downloading it.
 
     `estnltk.downloader.get_resource_paths(..., download_missing=False)` is a
     pure filesystem lookup against the local resources index — no network
     call, no interactive prompt.
+
+    Deliberately NOT cached, unlike `_wordnet()` below. Caching the probe
+    would reintroduce the very confusion issue #38 was about: an operator
+    sees `degraded: true`, runs `scripts/fetch_resources.py` as the message
+    tells them to, calls the tool again — and a cached `False` still says
+    degraded until they restart the process. The probe costs ~0.3 ms
+    against tool runtimes of 10 ms to 7 s, so there is nothing to buy here.
+    `_wordnet()` stays cached because it loads a heavy object, and it is
+    only ever reached once this returns True.
 
     This matters for more than tidiness. Calling `Wordnet()` on a machine
     that lacks the resource makes EstNLTK try to FETCH it, which would

--- a/server.py
+++ b/server.py
@@ -996,7 +996,25 @@ def _counted(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         _TOOL_CALLS[fn.__name__] = _TOOL_CALLS.get(fn.__name__, 0) + 1
-        return fn(*args, **kwargs)
+        try:
+            return fn(*args, **kwargs)
+        except LookupError as e:
+            # NLTK raises a LookupError with a wall of text telling the
+            # caller to run nltk.download() — advice this server
+            # deliberately does not follow (see _forbid_resource_downloads).
+            # Translate it once, here, into the instruction that actually
+            # applies. Costs nothing on the success path, and catching at
+            # the tool boundary covers every tool that builds a layer
+            # rather than needing a guard at ~19 call sites.
+            missing = "an NLTK resource"
+            for name in ("punkt_tab", "punkt"):
+                if name in str(e):
+                    missing = f"NLTK {name}"
+                    break
+            raise RuntimeError(
+                f"{missing} is not installed, so {fn.__name__} cannot run. "
+                f"{_RESOURCE_FETCH_HINT}"
+            ) from e
 
     return wrapper
 

--- a/server.py
+++ b/server.py
@@ -244,6 +244,13 @@ def _wordnet_available() -> bool:
         return bool(get_resource_paths("wordnet", only_latest=True,
                                        download_missing=False))
     except Exception:
+        # Load-bearing, not lazy. EstNLTK consults a local resources index,
+        # and when that index is itself absent it would want to fetch it
+        # from RESOURCES_INDEX_URL. Swallowing the failure and answering
+        # "not available" keeps the no-outbound-HTTP promise in the one
+        # case where the library would otherwise reach out. Pinned by
+        # tests/test_no_network.py, which deletes the index and asserts no
+        # connection is attempted.
         return False
 
 

--- a/server.py
+++ b/server.py
@@ -64,7 +64,7 @@ DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.2"
+SERVER_VERSION = "0.5.3"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -214,6 +214,29 @@ def _Text():
 def _vabamorf():
     from estnltk.vabamorf.morf import Vabamorf
     return Vabamorf.instance()
+
+
+@lru_cache(maxsize=1)
+def _wordnet_available() -> bool:
+    """True if Estonian WordNet is already on disk, WITHOUT downloading it.
+
+    `estnltk.downloader.get_resource_paths(..., download_missing=False)` is a
+    pure filesystem lookup against the local resources index — no network
+    call, no interactive prompt.
+
+    This matters for more than tidiness. Calling `Wordnet()` on a machine
+    that lacks the resource makes EstNLTK try to FETCH it, which would
+    breach the "no outbound HTTP calls" promise in PRIVACY.md, and it
+    prints its confirmation prompt to STDOUT — which under stdio transport
+    IS the MCP protocol channel, so it corrupts the stream. Checking first
+    means the running server never attempts either.
+    """
+    try:
+        from estnltk.downloader import get_resource_paths
+        return bool(get_resource_paths("wordnet", only_latest=True,
+                                       download_missing=False))
+    except Exception:
+        return False
 
 
 @lru_cache(maxsize=1)
@@ -1483,6 +1506,16 @@ def synonyms(word: Annotated[str, Field(description="A single Estonian word to l
     _check_text(word, limit=MAX_WORD_CHARS, name="word")
     if any(ch.isspace() for ch in word):
         raise ValueError("synonyms expects a single word, no whitespace")
+    # Fail with an actionable message rather than letting EstNLTK try to
+    # download the resource (outbound HTTP, which PRIVACY.md rules out) and
+    # print its prompt to stdout (the MCP protocol channel under stdio).
+    if not _wordnet_available():
+        raise RuntimeError(
+            "Estonian WordNet is not installed, so synonyms cannot run. "
+            "Fetch it with: uv run python scripts/fetch_resources.py "
+            "(the server never downloads resources by itself — see "
+            "PRIVACY.md)."
+        )
     wn = _wordnet()
     synsets = wn[word] or []
     out: list[dict] = []
@@ -1519,7 +1552,7 @@ def _classify_register(text: str) -> dict:
         if _first(list(span.partofspeech)) == "S":
             noun_count += 1
         # Test against both surface form and best lemma; lower-cased.
-        lemma = (list(span.lemma)[0] if span.lemma else "").lower()
+        lemma = (_first(list(span.lemma)) or "").lower()
         surface = word.lower()
         for candidate in {surface, lemma}:
             if not candidate:
@@ -1682,7 +1715,7 @@ def _check_capitalization(text: str) -> dict:
         if word.isupper() and len(word) > 1:
             continue
 
-        lemma_lower = (list(span.lemma)[0] if span.lemma else "").lower()
+        lemma_lower = (_first(list(span.lemma)) or "").lower()
         if not lemma_lower:
             continue
 
@@ -1727,7 +1760,7 @@ def _check_capitalization(text: str) -> dict:
             next_lemma = ""
             if i + 1 < len(spans):
                 next_lemma = (
-                    list(spans[i + 1].lemma)[0] if spans[i + 1].lemma else ""
+                    _first(list(spans[i + 1].lemma)) or ""
                 ).lower()
             if next_lemma in _CULTURE_NOUNS_ET:
                 rule = "language-adjective"
@@ -1948,7 +1981,7 @@ def _check_hyphenation(word: str) -> dict:
         }
     breaks: list[int] = []
     offset = 0
-    for i, s in enumerate(syls[:-1]):
+    for _i, s in enumerate(syls[:-1]):
         offset += len(s["syllable"])
         # poolitamine rule: don't leave <2 characters at either edge of
         # the broken word.
@@ -3687,34 +3720,30 @@ def _check_term_consistency(text: str) -> dict:
 
     # --- Rule B: shared WordNet synset.
     #
-    # WordNet ships pre-downloaded in the server image, so this is a local
-    # lookup with no network access. If the resource is somehow absent,
-    # EstNLTK tries to fetch it and prompts for confirmation — which would
-    # breach the no-outbound-network posture, and, worse, writes that
-    # prompt to STDOUT, which in stdio transport IS the MCP protocol
-    # channel. Redirecting stdout to stderr for the duration keeps the
-    # protocol stream clean whatever EstNLTK decides to print;
-    # BaseException covers the EOFError / SystemExit the prompt raises
-    # when stdin is closed. Rule B then degrades to off and `rules_run`
-    # says so rather than silently returning fewer groups.
-    import contextlib
-
+    # Check the resource is on disk FIRST (_wordnet_available is a pure
+    # filesystem lookup). The old code called Wordnet() and caught the
+    # fallout, which meant that on a machine without the resource EstNLTK
+    # would attempt a download — breaching the no-outbound-HTTP promise in
+    # PRIVACY.md — and print its prompt to stdout, which under stdio
+    # transport is the MCP protocol channel. Checking first means the
+    # running server never attempts either, and Rule B just reports itself
+    # as not run.
     ranked = [w for w, _ in counts.most_common(_TERM_CONSISTENCY_WORDNET_CAP)]
     synsets_by_lemma: dict[str, set[str]] = {}
-    wordnet_ok = True
-    try:
-        with contextlib.redirect_stdout(sys.stderr):
+    wordnet_ok = _wordnet_available()
+    if wordnet_ok:
+        try:
             wn = _wordnet()
-    except BaseException:
-        wn = None
-        wordnet_ok = False
-    if wn is not None:
-        for lemma in ranked:
-            try:
-                synsets_by_lemma[lemma] = {s.name for s in (wn[lemma] or [])}
-            except BaseException:
-                synsets_by_lemma[lemma] = set()
-                wordnet_ok = False
+        except Exception:
+            wn = None
+            wordnet_ok = False
+        if wn is not None:
+            for lemma in ranked:
+                try:
+                    synsets_by_lemma[lemma] = {s.name for s in (wn[lemma] or [])}
+                except Exception:
+                    synsets_by_lemma[lemma] = set()
+                    wordnet_ok = False
 
     seen_pairs: set[tuple[str, str]] = set()
     for i, a in enumerate(ranked):
@@ -3756,12 +3785,27 @@ def _check_term_consistency(text: str) -> dict:
             "shared-compound-head": True,
             "shared-wordnet-synset": wordnet_ok,
         },
+        # Top-level so a caller cannot miss it. A partial run that reports
+        # "nothing found" reads as a clean bill of health, which is exactly
+        # how a half-strength checker misleads someone — so say it here AND
+        # in summary_estonian, not only in rules_run.
+        "degraded": not wordnet_ok,
         "summary_estonian": (
-            f"Leiti {len(groups)} rühma, kus üht asja võidakse nimetada "
-            f"mitmel viisil. Vali igas rühmas üks termin ja kasuta seda "
-            f"läbivalt."
-            if groups else
-            "Ebajärjekindlat terminikasutust ei tuvastatud."
+            (
+                f"Leiti {len(groups)} rühma, kus üht asja võidakse nimetada "
+                f"mitmel viisil. Vali igas rühmas üks termin ja kasuta seda "
+                f"läbivalt."
+                if groups else
+                "Ebajärjekindlat terminikasutust ei tuvastatud."
+            )
+            + (
+                "" if wordnet_ok else
+                " TÄHELEPANU: tulemus on osaline. Eesti WordNet ei ole "
+                "paigaldatud, seetõttu jäi tähendusrühmade reegel "
+                "käivitamata ja osa kattuvaid termineid võib olla "
+                "leidmata. Paigalda ressurss käsuga "
+                "`uv run python scripts/fetch_resources.py`."
+            )
         ),
         "note": (
             "Heuristic terminology-consistency check: 'one referent, one "
@@ -3794,6 +3838,7 @@ class _TermConsistencyResult(TypedDict, total=False):
     groups: list[dict]
     terms_analysed: int
     rules_run: dict
+    degraded: bool
     summary_estonian: str
     note: str
 
@@ -4520,8 +4565,9 @@ def _build_http_app(token: str | None, rate_limit: int, public_mode: bool = Fals
 
 
 def _run_http(host: str, port: int, token: str | None, rate_limit: int, public_mode: bool) -> None:
-    import uvicorn  # local import; only needed in HTTP mode
     import atexit
+
+    import uvicorn  # local import; only needed in HTTP mode
 
     # Restore metrics from disk if a Fly volume (or local override) has them.
     _load_persistent_stats()

--- a/server.py
+++ b/server.py
@@ -216,41 +216,88 @@ def _vabamorf():
     return Vabamorf.instance()
 
 
-def _wordnet_available() -> bool:
-    """True if Estonian WordNet is already on disk, WITHOUT downloading it.
+_RESOURCE_FETCH_HINT = (
+    "Fetch it from a checkout with: uv run python scripts/fetch_resources.py "
+    "(the server never downloads resources by itself — see PRIVACY.md)."
+)
 
-    `estnltk.downloader.get_resource_paths(..., download_missing=False)` is a
-    pure filesystem lookup against the local resources index — no network
-    call, no interactive prompt.
+
+def _forbid_resource_downloads() -> None:
+    """Make PRIVACY.md's "no outbound HTTP calls" structural, not aspirational.
+
+    Two libraries below us will silently reach for the network mid-tool-call
+    if a resource is missing, and neither is reachable from our own call
+    sites, so guarding each tool individually cannot close them:
+
+    1. `estnltk.resource_utils.get_resources_index()` re-fetches its index
+       from RESOURCES_INDEX_URL whenever the local copy is missing OR older
+       than INDEX_TIMEOUT (2 h). On a long-lived server that is a periodic
+       outbound request, and when it fails the caller sees "resource
+       missing" rather than "lookup failed" — a false negative on top of a
+       broken promise. Setting the timeout to effectively infinite pins us
+       to the on-disk index.
+    2. `estnltk`'s sentence tokenizer catches `LookupError` for NLTK's
+       `punkt_tab` and calls `nltk.downloader.download()`. The `sentences`
+       layer is built by `tag_layer(["morph_analysis"])`, so nearly every
+       tool reaches it. Replacing the downloader with a refusal turns a
+       silent fetch into an actionable error.
+
+    Best-effort and non-fatal: if either library's internals move, we lose
+    the guard but not the server. tests/test_no_network.py is what actually
+    proves the promise holds.
+    """
+    try:
+        import estnltk.resource_utils as _ru
+        _ru.INDEX_TIMEOUT = sys.maxsize
+    except Exception:
+        pass
+
+    def _refuse(*args, **kwargs):
+        name = args[0] if args else kwargs.get("info_or_id", "a resource")
+        raise RuntimeError(
+            f"estonian-mcp does not download resources while serving "
+            f"(tried to fetch {name!r}). {_RESOURCE_FETCH_HINT}"
+        )
+
+    try:
+        import nltk
+        import nltk.downloader as _nd
+        _nd.download = _refuse
+        nltk.download = _refuse
+    except Exception:
+        pass
+
+
+_forbid_resource_downloads()
+
+
+def _wordnet_available() -> bool:
+    """True if Estonian WordNet is unpacked on disk, WITHOUT any network.
+
+    Checks the resources directory directly rather than calling
+    `get_resource_paths()`, which consults EstNLTK's resource *index* and
+    re-fetches that index over HTTPS when it is more than two hours old —
+    an outbound call from inside a tool, and a false "missing" verdict
+    whenever it fails. See _forbid_resource_downloads.
 
     Deliberately NOT cached, unlike `_wordnet()` below. Caching the probe
     would reintroduce the very confusion issue #38 was about: an operator
     sees `degraded: true`, runs `scripts/fetch_resources.py` as the message
     tells them to, calls the tool again — and a cached `False` still says
-    degraded until they restart the process. The probe costs ~0.3 ms
-    against tool runtimes of 10 ms to 7 s, so there is nothing to buy here.
-    `_wordnet()` stays cached because it loads a heavy object, and it is
-    only ever reached once this returns True.
-
-    This matters for more than tidiness. Calling `Wordnet()` on a machine
-    that lacks the resource makes EstNLTK try to FETCH it, which would
-    breach the "no outbound HTTP calls" promise in PRIVACY.md, and it
-    prints its confirmation prompt to STDOUT — which under stdio transport
-    IS the MCP protocol channel, so it corrupts the stream. Checking first
-    means the running server never attempts either.
+    degraded until they restart the process. The probe is a directory
+    listing; there is nothing to buy here. `_wordnet()` stays cached
+    because it loads a heavy object, and is only reached once this is True.
     """
     try:
-        from estnltk.downloader import get_resource_paths
-        return bool(get_resource_paths("wordnet", only_latest=True,
-                                       download_missing=False))
+        from estnltk.resource_utils import get_resources_dir
+        root = Path(get_resources_dir()) / "wordnet"
+        if not root.is_dir():
+            return False
+        # A version subdirectory with the sqlite files unpacked inside it.
+        return any(
+            any(child.glob("*.db")) for child in root.iterdir() if child.is_dir()
+        )
     except Exception:
-        # Load-bearing, not lazy. EstNLTK consults a local resources index,
-        # and when that index is itself absent it would want to fetch it
-        # from RESOURCES_INDEX_URL. Swallowing the failure and answering
-        # "not available" keeps the no-outbound-HTTP promise in the one
-        # case where the library would otherwise reach out. Pinned by
-        # tests/test_no_network.py, which deletes the index and asserts no
-        # connection is attempted.
         return False
 
 
@@ -260,15 +307,43 @@ def _wordnet():
     return Wordnet()
 
 
+# Where the fastText model may live, in priority order. The container path
+# comes first for the image; the cache path is where
+# scripts/fetch_resources.py puts it on a source install. Having only the
+# container default meant a source install could follow the documented
+# setup, be told "All resources present", and still fail every fastText
+# tool — the script cannot export a variable into the server process, and
+# JSON-configured MCP clients cannot run a shell `export` at all.
+_FASTTEXT_CANDIDATES: tuple[str, ...] = (
+    "/opt/models/fasttext-et-medium",
+    str(Path.home() / ".cache" / "estnltk-mcp" / "fasttext-et-medium"),
+)
+
+
+def _fasttext_path() -> str:
+    """Resolve the model path: explicit env override, else first candidate
+    that exists. Returns the container default when none exist, so the
+    error message names a concrete path."""
+    env = os.environ.get("ESTNLTK_MCP_FASTTEXT_PATH")
+    if env:
+        return env
+    for candidate in _FASTTEXT_CANDIDATES:
+        if Path(candidate).exists():
+            return candidate
+    return _FASTTEXT_CANDIDATES[0]
+
+
 @lru_cache(maxsize=1)
 def _embeddings():
     """Lazy-load the compressed fastText model used by find_related_words
     and check_compound_familiarity."""
     import compress_fasttext
-    path = os.environ.get(
-        "ESTNLTK_MCP_FASTTEXT_PATH",
-        "/opt/models/fasttext-et-medium",
-    )
+    path = _fasttext_path()
+    if not Path(path).exists():
+        raise RuntimeError(
+            f"The fastText model is not installed (looked in "
+            f"{', '.join(_FASTTEXT_CANDIDATES)}). {_RESOURCE_FETCH_HINT}"
+        )
     return compress_fasttext.models.CompressedFastTextKeyedVectors.load(path)
 
 
@@ -3816,8 +3891,8 @@ def _check_term_consistency(text: str) -> dict:
             + (
                 "" if wordnet_ok else
                 " TÄHELEPANU: tulemus on osaline. Eesti WordNet ei ole "
-                "paigaldatud, seetõttu jäi tähendusrühmade reegel "
-                "käivitamata ja osa kattuvaid termineid võib olla "
+                "paigaldatud, mistõttu jäi tähendusrühmade reegel "
+                "käivitamata ja osa kattuvaid termineid võib jääda "
                 "leidmata. Paigalda ressurss käsuga "
                 "`uv run python scripts/fetch_resources.py`."
             )
@@ -3830,7 +3905,10 @@ def _check_term_consistency(text: str) -> dict:
             "compounds sharing a head is deliberately NOT enough, since "
             "those are usually distinct things. Rule "
             "`shared-wordnet-synset` fires when two lemmas sit in the same "
-            "Estonian WordNet synset. The tool does NOT decide which "
+            "Estonian WordNet synset — and does not run at all when that "
+            "resource is missing, in which case `degraded` is true and an "
+            "empty `groups` list means only that the compound-head rule "
+            "found nothing. The tool does NOT decide which "
             "variant is correct — that needs domain context it cannot see; "
             "it reports counts so you can pick the dominant term, and some "
             "groups are legitimately distinct concepts. KNOWN GAP: "
@@ -3883,6 +3961,13 @@ def check_term_consistency(text: Annotated[str, Field(description="Estonian docu
     one, so you can standardise on the most-used term. The tool does not
     decide which variant is right — some groups are genuinely distinct
     concepts, so read them before rewriting.
+
+    CHECK `degraded` BEFORE TRUSTING AN EMPTY RESULT. When Estonian WordNet
+    is not installed, the `shared-wordnet-synset` rule cannot run; the tool
+    then returns `degraded: true`, says so in `summary_estonian`, and marks
+    the rule false in `rules_run`. "No groups found" from a degraded run
+    means "the compound-head rule found nothing", NOT "the terminology is
+    consistent".
 
     Known gap: synonyms sharing neither a head nor a synset (korpus /
     andmestik) are not caught. Input capped at 100,000 characters.

--- a/tests/test_familiarity.py
+++ b/tests/test_familiarity.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import server  # noqa: E402
+import server
 
 failures: list[str] = []
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -22,7 +22,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import httpx  # transitive dep of mcp
-import server  # noqa: E402
+
+import server
 
 failures: list[str] = []
 

--- a/tests/test_legal.py
+++ b/tests/test_legal.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import server  # noqa: E402
+import server
 
 failures: list[str] = []
 

--- a/tests/test_no_network.py
+++ b/tests/test_no_network.py
@@ -1,0 +1,207 @@
+"""PRIVACY.md says the running server makes no outbound HTTP calls. This
+test enforces it instead of trusting it.
+
+Every tool is invoked with `socket.socket.connect` and
+`socket.create_connection` replaced by a raiser, so any attempt to open an
+outbound connection fails loudly and names the tool that tried.
+
+Why this exists: issues #37 and #38 were both symptoms of resource
+handling that reached for the network when something was missing. The old
+`check_term_consistency` called `Wordnet()` and caught the fallout, which
+meant EstNLTK would try to FETCH the resource — and print an interactive
+prompt to stdout, which under stdio transport is the MCP protocol channel.
+A promise in a markdown file did not stop that; a test does.
+
+Two scenarios are covered for the availability probe specifically:
+  A. EstNLTK's local resources index is present (the normal case).
+  B. The index is absent — EstNLTK would want to fetch it from
+     RESOURCES_INDEX_URL. The probe must still answer locally and return
+     False rather than reaching out.
+
+Run via:
+
+    uv run python tests/test_no_network.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server
+
+failures: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+class NetworkBlocked(AssertionError):
+    """Raised in place of any outbound connection attempt."""
+
+
+_real_connect = socket.socket.connect
+_real_create = socket.create_connection
+
+
+def _arm() -> None:
+    def _blocked(*a, **k):
+        target = a[1] if len(a) > 1 else (a[0] if a else "?")
+        raise NetworkBlocked(f"outbound connection attempted to {target!r}")
+    socket.socket.connect = _blocked
+    socket.create_connection = _blocked
+
+
+def _disarm() -> None:
+    socket.socket.connect = _real_connect
+    socket.create_connection = _real_create
+
+
+# One representative call per tool. Args are deliberately small: this test
+# is about network behaviour, not linguistic correctness.
+TOOL_CALLS: dict[str, tuple] = {
+    "tokenize": ("Tere maailm. Teine lause.",),
+    "lemmatize": ("Koerad jooksevad.",),
+    "pos_tag": ("Koerad jooksevad.",),
+    "analyze_morphology": ("Koerad jooksevad.",),
+    "spell_check": ("Tere maailm",),
+    "syllabify": ("koerad",),
+    "named_entities": ("Tallinn on Eesti pealinn.",),
+    "paradigm": ("koer",),
+    "synonyms": ("kohv",),
+    "find_related_words": ("kohv",),
+    "classify_register": ("Käesoleva lepingu alusel sätestatakse kohustused.",),
+    "check_style": ("Süsteem kasutab andmeid. Andmed töödeldakse.",),
+    "check_officialese": ("Aruandeperioodil koguti ja valideeriti andmestik.",),
+    "check_term_consistency": ("Andmestik ja teadusandmestik.",),
+    "check_compounds": ("Kooli maja on suur.",),
+    "check_punctuation": ("Ma tean et see on hea.",),
+    "check_capitalization": ("Olen Eestlane.",),
+    "check_numbers": ("Pi on 3.14.",),
+    "check_redundancy": ("Samuti ka.",),
+    "check_object_case": ("Ma ei näen koera.",),
+    "check_abbreviation_hyphenation": ("MCPst tuleb abi.",),
+    "check_compound_familiarity": ("See on mõtteliin.",),
+    "check_hyphenation": ("koerad",),
+    "check_legalese": ("Käesolev leping.",),
+    "check_defined_terms": ('Müüja (edaspidi «Müüja») müüb kauba.',),
+    "common_legal_usage": ("hagi",),
+}
+
+
+def _warm() -> None:
+    """Load the lazy models BEFORE arming, so a genuine local disk read is
+    not conflated with a network call. Each is best-effort: on a machine
+    without a given resource the tool is expected to fail, and that is what
+    the resource tests cover."""
+    for name, args in (
+        ("spell_check", ("Tere",)),
+        ("named_entities", ("Tallinn on linn.",)),
+        ("synonyms", ("kohv",)),
+        ("find_related_words", ("kohv",)),
+    ):
+        try:
+            getattr(server, name)(*args)
+        except Exception:
+            pass
+
+
+def every_tool_is_offline() -> None:
+    print("no tool opens an outbound connection")
+    _warm()
+    attempted: list[str] = []
+    _arm()
+    try:
+        for name, args in TOOL_CALLS.items():
+            try:
+                getattr(server, name)(*args)
+            except NetworkBlocked as e:
+                attempted.append(f"{name}: {e}")
+            except Exception:
+                # Any other failure (missing resource, bad input) is out of
+                # scope here — only network behaviour is under test.
+                pass
+    finally:
+        _disarm()
+
+    check(f"all {len(TOOL_CALLS)} tools ran without outbound connections",
+          not attempted, "; ".join(attempted))
+    # Guard against the list silently drifting out of sync with the server.
+    registered = {t.name for t in _registered_tools()}
+    missing = registered - set(TOOL_CALLS)
+    check("every registered tool is covered by this test",
+          not missing, f"uncovered: {sorted(missing)}")
+
+
+def _registered_tools():
+    import asyncio
+    return asyncio.run(server.mcp.list_tools())
+
+
+def availability_probe_never_reaches_out() -> None:
+    """The probe must answer from disk even when EstNLTK's local resources
+    index is missing — that is precisely when EstNLTK would want to fetch
+    it from RESOURCES_INDEX_URL."""
+    print("_wordnet_available never reaches the network")
+    from estnltk.resource_utils import get_resources_dir
+
+    idx = Path(get_resources_dir()) / "resources_index.json"
+
+    _arm()
+    try:
+        try:
+            a = server._wordnet_available()
+            check("index present: answers locally", isinstance(a, bool), repr(a))
+        except NetworkBlocked as e:
+            check("index present: answers locally", False, str(e))
+    finally:
+        _disarm()
+
+    if not idx.exists():
+        print("  SKIP index-missing case (no local index to move aside)")
+        return
+
+    bak = idx.with_suffix(".json.testbak")
+    shutil.move(str(idx), str(bak))
+    _arm()
+    try:
+        b = server._wordnet_available()
+        check("index missing: still answers locally, no fetch",
+              b is False, repr(b))
+    except NetworkBlocked as e:
+        check("index missing: still answers locally, no fetch", False, str(e))
+    finally:
+        _disarm()
+        shutil.move(str(bak), str(idx))
+    check("resources index restored", idx.exists())
+
+
+def server_module_has_no_http_client() -> None:
+    """A cheap structural guard: the served module should not import an
+    HTTP client. urllib is fine to have available, but the server must not
+    be reaching for requests/httpx to talk to anyone."""
+    print("server module imports no HTTP client")
+    src = Path(server.__file__).read_text(encoding="utf-8")
+    for mod in ("import requests", "import httpx", "from requests", "from httpx"):
+        check(f"no `{mod}` in server.py", mod not in src)
+
+
+every_tool_is_offline()
+availability_probe_never_reaches_out()
+server_module_has_no_http_client()
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print(f"\nall no-network tests passed ({os.path.basename(__file__)})")

--- a/tests/test_no_network.py
+++ b/tests/test_no_network.py
@@ -25,9 +25,10 @@ Run via:
 from __future__ import annotations
 
 import os
-import shutil
 import socket
 import sys
+import tempfile
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -51,19 +52,37 @@ class NetworkBlocked(AssertionError):
 
 _real_connect = socket.socket.connect
 _real_create = socket.create_connection
+_real_getaddrinfo = socket.getaddrinfo
+
+# Every blocked attempt is RECORDED here before the exception is raised.
+# Raising alone is not enough: the code under test catches broad exceptions
+# by design, which silently converts "a connection was attempted" into "the
+# test saw nothing" and passes. The earlier version of this file did
+# exactly that and passed against a live privacy violation.
+ATTEMPTS: list[str] = []
 
 
 def _arm() -> None:
+    ATTEMPTS.clear()
+
     def _blocked(*a, **k):
         target = a[1] if len(a) > 1 else (a[0] if a else "?")
+        ATTEMPTS.append(repr(target))
         raise NetworkBlocked(f"outbound connection attempted to {target!r}")
+
+    def _blocked_dns(host, *a, **k):
+        ATTEMPTS.append(f"DNS {host!r}")
+        raise NetworkBlocked(f"DNS lookup attempted for {host!r}")
+
     socket.socket.connect = _blocked
     socket.create_connection = _blocked
+    socket.getaddrinfo = _blocked_dns          # DNS is egress too
 
 
 def _disarm() -> None:
     socket.socket.connect = _real_connect
     socket.create_connection = _real_create
+    socket.getaddrinfo = _real_getaddrinfo
 
 
 # One representative call per tool. Args are deliberately small: this test
@@ -133,8 +152,11 @@ def every_tool_is_offline() -> None:
     finally:
         _disarm()
 
+    # ATTEMPTS is the real assertion: a tool that swallows NetworkBlocked
+    # still leaves a record here.
     check(f"all {len(TOOL_CALLS)} tools ran without outbound connections",
-          not attempted, "; ".join(attempted))
+          not ATTEMPTS and not attempted,
+          f"recorded={ATTEMPTS[:5]} raised={attempted[:3]}")
     # Guard against the list silently drifting out of sync with the server.
     registered = {t.name for t in _registered_tools()}
     missing = registered - set(TOOL_CALLS)
@@ -148,41 +170,76 @@ def _registered_tools():
 
 
 def availability_probe_never_reaches_out() -> None:
-    """The probe must answer from disk even when EstNLTK's local resources
-    index is missing — that is precisely when EstNLTK would want to fetch
-    it from RESOURCES_INDEX_URL."""
+    """The probe must answer from disk in the two states where EstNLTK
+    would otherwise fetch its resources index over HTTPS:
+
+      A. index STALE — the production steady state. EstNLTK refreshes any
+         index older than INDEX_TIMEOUT (2 h), so a server up longer than
+         that made an outbound call on the next lookup. This is the case
+         the previous version of this file never covered.
+      B. index ABSENT.
+
+    Uses ESTNLTK_RESOURCES to point at a temp dir rather than moving the
+    developer's venv copy aside, so a killed process cannot corrupt it.
+    """
     print("_wordnet_available never reaches the network")
-    from estnltk.resource_utils import get_resources_dir
+    import estnltk.resource_utils as ru
 
-    idx = Path(get_resources_dir()) / "resources_index.json"
-
-    _arm()
-    try:
+    # A. stale index, real resources dir.
+    idx = Path(ru.get_resources_dir()) / "resources_index.json"
+    if idx.exists():
+        original = idx.stat().st_mtime
+        stale = time.time() - 100_000        # far beyond any INDEX_TIMEOUT
+        os.utime(idx, (stale, stale))
+        _arm()
         try:
-            a = server._wordnet_available()
-            check("index present: answers locally", isinstance(a, bool), repr(a))
-        except NetworkBlocked as e:
-            check("index present: answers locally", False, str(e))
-    finally:
-        _disarm()
+            server._wordnet_available()
+        except NetworkBlocked:
+            pass
+        finally:
+            _disarm()
+            os.utime(idx, (original, original))
+        check("stale index: no outbound call", not ATTEMPTS, str(ATTEMPTS[:3]))
+    else:
+        print("  SKIP stale-index case (no local index present)")
 
-    if not idx.exists():
-        print("  SKIP index-missing case (no local index to move aside)")
-        return
+    # B. absent index, via an isolated resources dir.
+    with tempfile.TemporaryDirectory() as tmp:
+        prev = os.environ.get("ESTNLTK_RESOURCES")
+        os.environ["ESTNLTK_RESOURCES"] = tmp
+        _arm()
+        try:
+            result = server._wordnet_available()
+        except NetworkBlocked:
+            result = None
+        finally:
+            _disarm()
+            if prev is None:
+                os.environ.pop("ESTNLTK_RESOURCES", None)
+            else:
+                os.environ["ESTNLTK_RESOURCES"] = prev
+        check("absent index: no outbound call", not ATTEMPTS, str(ATTEMPTS[:3]))
+        check("absent index: reports unavailable rather than raising",
+              result is False, repr(result))
 
-    bak = idx.with_suffix(".json.testbak")
-    shutil.move(str(idx), str(bak))
-    _arm()
+
+def index_refresh_is_pinned() -> None:
+    """_forbid_resource_downloads must neutralise both auto-fetch paths."""
+    print("resource auto-download is structurally refused")
+    import estnltk.resource_utils as ru
+    check("EstNLTK index refresh is pinned (no periodic re-fetch)",
+          ru.INDEX_TIMEOUT > 10 ** 9, str(ru.INDEX_TIMEOUT))
+
+    import nltk.downloader as nd
+    raised = None
     try:
-        b = server._wordnet_available()
-        check("index missing: still answers locally, no fetch",
-              b is False, repr(b))
-    except NetworkBlocked as e:
-        check("index missing: still answers locally, no fetch", False, str(e))
-    finally:
-        _disarm()
-        shutil.move(str(bak), str(idx))
-    check("resources index restored", idx.exists())
+        nd.download("punkt_tab")
+    except Exception as e:
+        raised = e
+    check("nltk.downloader.download refuses instead of fetching",
+          isinstance(raised, RuntimeError), f"{type(raised).__name__}: {raised}")
+    check("refusal message is actionable",
+          raised is not None and "fetch_resources.py" in str(raised), str(raised))
 
 
 def server_module_has_no_http_client() -> None:
@@ -197,6 +254,7 @@ def server_module_has_no_http_client() -> None:
 
 every_tool_is_offline()
 availability_probe_never_reaches_out()
+index_refresh_is_pinned()
 server_module_has_no_http_client()
 
 if failures:

--- a/tests/test_officialese.py
+++ b/tests/test_officialese.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import server  # noqa: E402
+import server
 
 failures: list[str] = []
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,186 @@
+"""Tests for resource-availability handling (issues #37 and #38).
+
+The defect these pin down: `check_term_consistency` returned
+"Ebajärjekindlat terminikasutust ei tuvastatud" — a confident negative —
+while one of its two rules was switched off because Estonian WordNet was
+missing. The only signal was a `rules_run` flag a caller had to know to
+read. A partial run that reads as a clean bill of health is worse than a
+crash, so degradation must be visible in the human-facing summary.
+
+Also pins the privacy-relevant half: the running server must never attempt
+to DOWNLOAD a missing resource. PRIVACY.md promises no outbound HTTP calls,
+and under stdio transport EstNLTK's download prompt goes to stdout, which
+is the MCP protocol channel.
+
+Runs with or without WordNet installed — the degraded path is exercised by
+monkeypatching availability, not by requiring a broken environment.
+
+Run via:
+
+    uv run python tests/test_resources.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server
+
+failures: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+DOC = "Andmestik ja teadusandmestik ning pildiandmestik. Andmestik on avalik."
+
+
+def _with_wordnet(available: bool):
+    """Force _wordnet_available to a given answer, restoring afterwards.
+
+    Swaps the module attribute rather than clearing the lru_cache, because
+    the production code resolves `_wordnet_available` through a module
+    global at call time — so replacing the attribute is what actually takes
+    effect, and it leaves the real cache untouched for later tests.
+    """
+    real_avail = server._wordnet_available
+    real_wn = server._wordnet
+
+    class _Ctx:
+        def __enter__(self):
+            server._wordnet_available = lambda: available
+            if not available:
+                def _boom():
+                    raise AssertionError(
+                        "_wordnet() must NOT be called when the resource is "
+                        "unavailable — that is what triggers a download "
+                        "attempt and the stdout prompt"
+                    )
+                server._wordnet = _boom
+            return self
+
+        def __exit__(self, *a):
+            server._wordnet_available = real_avail
+            server._wordnet = real_wn
+            return False
+
+    return _Ctx()
+
+
+def degraded_is_visible() -> None:
+    """Issue #38: a half-strength run must say so where a human will see it."""
+    print("check_term_consistency — degraded run is visible")
+
+    with _with_wordnet(False):
+        r = server.check_term_consistency(DOC)
+
+    check("rules_run reports the WordNet rule did not run",
+          r["rules_run"]["shared-wordnet-synset"] is False, str(r["rules_run"]))
+    check("compound-head rule still ran",
+          r["rules_run"]["shared-compound-head"] is True, str(r["rules_run"]))
+    check("top-level degraded flag is set",
+          r.get("degraded") is True, str(r.get("degraded")))
+    summary = r["summary_estonian"]
+    check("summary warns the result is partial",
+          "osaline" in summary, summary)
+    check("summary names the missing resource",
+          "WordNet" in summary, summary)
+    check("summary tells the caller how to fix it",
+          "fetch_resources.py" in summary, summary)
+    # The original bug: a clean-sounding negative with no caveat attached.
+    check("a no-findings degraded run is NOT a bare clean bill of health",
+          not summary.strip().endswith("ei tuvastatud."), summary)
+
+
+def healthy_run_is_not_polluted() -> None:
+    """The warning must appear ONLY when degraded — otherwise it is noise
+    and callers learn to ignore it."""
+    print("check_term_consistency — healthy run stays clean")
+
+    with _with_wordnet(True):
+        r = server.check_term_consistency(DOC)
+
+    check("degraded is False when WordNet is available",
+          r.get("degraded") is False, str(r.get("degraded")))
+    check("no partial-result warning in the summary",
+          "osaline" not in r["summary_estonian"], r["summary_estonian"])
+    check("rules_run shows both rules ran",
+          r["rules_run"] == {"shared-compound-head": True,
+                             "shared-wordnet-synset": True},
+          str(r["rules_run"]))
+    # The compound-head rule is independent of WordNet, so the real finding
+    # must survive either way.
+    check("the andmestik group is still found",
+          any(g["rule"] == "shared-compound-head" for g in r["groups"]),
+          str(r["groups"]))
+
+
+def no_download_attempt_at_runtime() -> None:
+    """PRIVACY.md: the running server makes no outbound HTTP calls.
+
+    _with_wordnet(False) installs a _wordnet() that raises if called, so
+    this test fails loudly if the degraded path ever goes back to
+    "call it and catch the fallout".
+    """
+    print("no resource download is attempted while serving")
+
+    with _with_wordnet(False):
+        r = server.check_term_consistency(DOC)  # must not raise
+    check("degraded run completes without calling _wordnet()",
+          r["rules_run"]["shared-wordnet-synset"] is False)
+
+    with _with_wordnet(False):
+        raised = None
+        try:
+            server.synonyms("korpus")
+        except Exception as e:
+            raised = e
+    check("synonyms raises rather than downloading",
+          isinstance(raised, RuntimeError), f"{type(raised).__name__}: {raised}")
+    msg = str(raised)
+    check("synonyms error names the fix",
+          "fetch_resources.py" in msg, msg)
+    check("synonyms error explains the no-download policy",
+          "PRIVACY.md" in msg, msg)
+
+
+def availability_probe_is_local_only() -> None:
+    """_wordnet_available must answer from disk, never from the network."""
+    print("_wordnet_available — pure local probe")
+    v = server._wordnet_available()
+    check("returns a bool", isinstance(v, bool), repr(v))
+    # Cached, so repeated calls cannot turn into repeated probes.
+    check("is cached", server._wordnet_available() is v)
+    check("has a cache_clear (lru_cache applied)",
+          hasattr(server._wordnet_available, "cache_clear"))
+
+
+def schema_advertises_degraded() -> None:
+    print("output schema")
+    ann = server._TermConsistencyResult.__annotations__
+    check("degraded is in the TypedDict", "degraded" in ann, str(sorted(ann)))
+    # server.py uses `from __future__ import annotations`, so annotations are
+    # ForwardRef/str rather than the type object.
+    check("degraded is typed bool",
+          "bool" in str(ann.get("degraded")), str(ann.get("degraded")))
+
+
+degraded_is_visible()
+healthy_run_is_not_polluted()
+no_download_attempt_at_runtime()
+availability_probe_is_local_only()
+schema_advertises_degraded()
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("\nall resource-handling tests passed")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -12,8 +12,10 @@ to DOWNLOAD a missing resource. PRIVACY.md promises no outbound HTTP calls,
 and under stdio transport EstNLTK's download prompt goes to stdout, which
 is the MCP protocol channel.
 
-Runs with or without WordNet installed — the degraded path is exercised by
-monkeypatching availability, not by requiring a broken environment.
+Runs with or without WordNet installed. BOTH paths are faked: the
+available=True path uses a stand-in WordNet rather than the real resource,
+so running this suite on a fresh clone cannot itself trigger the download
+and stdin prompt that the change forbids.
 
 Run via:
 
@@ -53,10 +55,25 @@ def _with_wordnet(available: bool):
     real_avail = server._wordnet_available
     real_wn = server._wordnet
 
+    class _FakeWordnet:
+        """Deterministic stand-in so the available=True path never touches
+        the real resource. Without this, running these tests on the very
+        machine this change targets — a fresh clone with no WordNet — would
+        itself trigger EstNLTK's download and stdin prompt, i.e. the exact
+        behaviour under test."""
+
+        class _Synset:
+            def __init__(self, name): self.name = name
+
+        def __getitem__(self, lemma):
+            return [self._Synset("test.n.01")] if lemma == "andmestik" else []
+
     class _Ctx:
         def __enter__(self):
             server._wordnet_available = lambda: available
-            if not available:
+            if available:
+                server._wordnet = lambda: _FakeWordnet()
+            else:
                 def _boom():
                     raise AssertionError(
                         "_wordnet() must NOT be called when the resource is "
@@ -167,19 +184,28 @@ def availability_probe_is_local_only() -> None:
           "an lru_cache here would go stale after the operator installs "
           "the resource mid-process")
 
-    # Prove it re-probes: flip the underlying answer and confirm the next
-    # call reflects it without any cache invalidation step.
-    import estnltk.downloader as dl
-    real = dl.get_resource_paths
+    # Prove it re-probes: point the resources dir at an empty tree, then at
+    # one containing an unpacked WordNet, and confirm each call reflects the
+    # current state with no cache-invalidation step in between.
+    import tempfile
+
+    import estnltk.resource_utils as ru
+    real_dir = ru.get_resources_dir
     try:
-        dl.get_resource_paths = lambda *a, **k: None
-        check("re-probes and sees a resource disappear",
-              server._wordnet_available() is False)
-        dl.get_resource_paths = lambda *a, **k: ["/fake/wordnet"]
-        check("re-probes and sees a resource appear",
-              server._wordnet_available() is True)
+        with tempfile.TemporaryDirectory() as empty:
+            ru.get_resources_dir = lambda: empty
+            check("re-probes and sees a resource disappear",
+                  server._wordnet_available() is False)
+
+        with tempfile.TemporaryDirectory() as populated:
+            wn = Path(populated) / "wordnet" / "estwn-et-2.7.0"
+            wn.mkdir(parents=True)
+            (wn / "wordnet_entry.db").write_bytes(b"")
+            ru.get_resources_dir = lambda: populated
+            check("re-probes and sees a resource appear",
+                  server._wordnet_available() is True)
     finally:
-        dl.get_resource_paths = real
+        ru.get_resources_dir = real_dir
     check("restored real probe still returns a bool",
           isinstance(server._wordnet_available(), bool))
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -152,14 +152,36 @@ def no_download_attempt_at_runtime() -> None:
 
 
 def availability_probe_is_local_only() -> None:
-    """_wordnet_available must answer from disk, never from the network."""
-    print("_wordnet_available — pure local probe")
+    """_wordnet_available must answer from disk, never from the network,
+    and must NOT be cached."""
+    print("_wordnet_available — pure local, uncached probe")
     v = server._wordnet_available()
     check("returns a bool", isinstance(v, bool), repr(v))
-    # Cached, so repeated calls cannot turn into repeated probes.
-    check("is cached", server._wordnet_available() is v)
-    check("has a cache_clear (lru_cache applied)",
-          hasattr(server._wordnet_available, "cache_clear"))
+
+    # Not cached, on purpose. A cached probe reintroduces exactly the
+    # confusion issue #38 was about: the operator is told to run
+    # fetch_resources.py, does so, calls the tool again, and a stale False
+    # still reports degraded until the process restarts.
+    check("probe is NOT lru_cached",
+          not hasattr(server._wordnet_available, "cache_clear"),
+          "an lru_cache here would go stale after the operator installs "
+          "the resource mid-process")
+
+    # Prove it re-probes: flip the underlying answer and confirm the next
+    # call reflects it without any cache invalidation step.
+    import estnltk.downloader as dl
+    real = dl.get_resource_paths
+    try:
+        dl.get_resource_paths = lambda *a, **k: None
+        check("re-probes and sees a resource disappear",
+              server._wordnet_available() is False)
+        dl.get_resource_paths = lambda *a, **k: ["/fake/wordnet"]
+        check("re-probes and sees a resource appear",
+              server._wordnet_available() is True)
+    finally:
+        dl.get_resource_paths = real
+    check("restored real probe still returns a bool",
+          isinstance(server._wordnet_available(), bool))
 
 
 def schema_advertises_degraded() -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import server  # noqa: E402
+import server
 
 failures: list[str] = []
 
@@ -472,7 +472,8 @@ check("increments by exactly 1", server._TOOL_CALLS.get("tokenize", 0) == before
       f"{before} -> {server._TOOL_CALLS.get('tokenize', 0)}")
 
 print("schema quality (Smithery score guard)")
-import asyncio as _asyncio
+import asyncio as _asyncio  # noqa: E402  (deliberate: guard runs after the tool suite)
+
 _tools = _asyncio.run(server.mcp.list_tools())
 _missing_desc = [
     f"{t.name}.{p}"

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -355,7 +355,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },
@@ -569,7 +569,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -737,17 +737,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -764,18 +764,18 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -787,7 +787,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1330,10 +1330,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1383,9 +1383,9 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -1436,7 +1436,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2068,10 +2068,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -2112,10 +2112,10 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -2153,7 +2153,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2214,7 +2214,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2428,8 +2428,8 @@ name = "uvicorn"
 version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Fixes #37 and #38, both reported by @Kivaste against 0.5.1.

## First, the question #37 asked and could not answer

> That makes me suspect the published image and the Connectors Directory build hit the same failure. **I have not verified that.**

**They don't.** I called both affected tools on the live deployment before changing anything:

```
check_compounds         -> OK
check_term_consistency  -> OK, rules_run: both true, not degraded
```

So both issues are source-install-only. The image was fine — but it was fine *by accident*, which is its own problem, addressed below.

## #38 — a confident negative from a half-strength checker

With Estonian WordNet missing, `check_term_consistency` returned `"Ebajärjekindlat terminikasutust ei tuvastatud"` — reads as a clean bill of health — while the `shared-wordnet-synset` rule had never run. The only signal was a `rules_run` flag you had to know to read. The reporter put it exactly right: a crash is honest, this wasn't.

Now the degradation is stated in `summary_estonian` itself, in Estonian, with the command that fixes it, plus a top-level `degraded` boolean:

```
TÄHELEPANU: tulemus on osaline. Eesti WordNet ei ole paigaldatud,
seetõttu jäi tähendusrühmade reegel käivitamata ja osa kattuvaid
termineid võib olla leidmata. Paigalda ressurss käsuga
`uv run python scripts/fetch_resources.py`.
```

## The privacy half, which matters more than the bug

The old code called `Wordnet()` and caught the fallout. On a machine without the resource that meant EstNLTK would **attempt a network download** — breaching the "no outbound HTTP calls" promise in PRIVACY.md — and print its confirmation prompt to **stdout**, which under stdio transport *is* the MCP protocol channel.

`_wordnet_available()` now checks the filesystem first via `get_resource_paths(download_missing=False)`, so neither can happen. `synonyms` raises an actionable error instead of hanging or downloading.

**This is now enforced, not just promised.** `tests/test_no_network.py` invokes all 26 tools with `socket.connect` replaced by a raiser, and separately deletes EstNLTK's resources index — precisely when the library would want to fetch it — and asserts the probe still answers locally. It cross-checks its tool list against `mcp.list_tools()`, so it fails if a future tool is added uncovered.

## #37 — the missing setup step

`scripts/fetch_resources.py` fetches `punkt_tab`, WordNet and fastText. None can come from `uv.lock`, because they're *data*, not Python distributions. It sets `SSL_CERT_FILE` from `certifi` first — uv-provisioned interpreters ship without a CA trust store, so the documented `nltk.download()` route fails with `CERTIFICATE_VERIFY_FAILED`. Credit to the reporter for diagnosing that. fastText is checksum-verified and only moved into place after verification, so an interrupted download can't masquerade as a good model. Idempotent.

It's a script rather than lazy auto-download **on purpose**: the network access is the operator's, at setup time, never the server's at request time.

Concrete effect — the smoke suite locally went from halting at 30 checks to **126 passing**.

## Made the image correct by construction

The Dockerfile now fetches `punkt_tab` explicitly. Note the non-obvious part: this is a multi-stage build and the runtime stage copies only `/opt/venv`, `/opt/models` and `/app`. NLTK's default target for root is `/root/nltk_data`, which is **never copied** — a naive `nltk.download()` would have passed every build assertion and still shipped an image without the data. It downloads into `/opt/venv/nltk_data`, which rides along with the venv and is on NLTK's search path at runtime.

CI's container test now calls `check_compounds` and asserts `check_term_consistency` comes back `degraded: false`, so the image can't regress into serving confident-but-partial answers.

## Self-review found two of its own bugs

- `_wordnet_available` was `@lru_cache`d. That reintroduced the exact confusion #38 was about: the tool tells you to run the script, you do, you call again — and a cached `False` still says degraded until restart. The probe costs ~0.3 ms; the cache bought nothing. Removed, with a test that exercises the operator recovery path.
- `uv.lock` was stale at 0.5.1 and CI runs `uv sync --frozen`, so this **would have failed CI**. Synced; no dependency versions move.

## Also

`ruff.toml` + a CI lint job, so "lint passes" is verifiable rather than aspirational. The config encodes conventions this codebase already follows (blind excepts on resource loads, Estonian typography) instead of fighting them.

## Verification

- 336 checks across 7 suites, all passing
- `ruff check .` clean
- New: `tests/test_resources.py` (22 checks), `tests/test_no_network.py` (9 checks)

No tool behaviour changes when resources are present — only the degraded path and the error messages differ.
