### PR TITLE
0.5.4 (security): per-IP rate limit could be evaded by varying X-Forwarded-For

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Run no-outbound-network tests
         run: uv run --python ${{ matrix.python-version }} python tests/test_no_network.py
 
+      - name: Run client-IP bucketing tests (rate-limit evasion)
+        run: uv run --python ${{ matrix.python-version }} python tests/test_client_ip.py
+
   # Proves the DOCUMENTED source-install path works, from a clean state.
   # The existing `smoke` job pre-fetches resources through bespoke steps and
   # exports ESTNLTK_MCP_FASTTEXT_PATH, which masks exactly the class of bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.4] — 2026-08-23
+
+### Security
+
+- **The public per-IP rate limit could be evaded entirely by varying
+  `X-Forwarded-For`.** `_client_ip` returned `scope["client"][0]`, which
+  uvicorn (`proxy_headers=True`, `forwarded_allow_ips="*"`) had rewritten
+  from the **leftmost** XFF entry. A proxy *appends* to whatever the caller
+  sent, so that entry is entirely caller-controlled: every request with a
+  different header got its own fresh bucket, and the public deployment's
+  only DoS protection did nothing.
+
+  Reproduced against a local server in public mode at a 5/min limit — a
+  fixed spoofed value gets 429 after five requests, rotating values stay
+  200 indefinitely. `SECURITY.md` asserted the opposite and has been
+  corrected.
+
+  `_client_ip` now reads the **Nth-from-right** entry, where N is
+  `ESTNLTK_MCP_TRUSTED_PROXY_HOPS` (default 1 for Fly's single edge proxy).
+  A caller cannot append after a proxy, so this is correct whether the edge
+  appends to a client-supplied header or replaces it. uvicorn's
+  `proxy_headers` is now **off**, because the fallback needs
+  `scope["client"]` to be the real peer — with it on, even
+  `TRUSTED_PROXY_HOPS=0` stayed bypassable, which the tests caught.
+
+  Set `ESTNLTK_MCP_TRUSTED_PROXY_HOPS=0` if you run the server directly
+  exposed with no proxy in front.
+
+  Surfaced while reviewing PR #36; credit to @laazik, whose nginx config
+  prompted the question even though the bug is ours, not theirs.
+
 ## [0.5.3] — 2026-08-23
 
 Fixes both issues reported by @Kivaste against 0.5.1. Neither affected the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,10 +70,19 @@ silly-geese-hosted public Smithery listing. Defences:
 
 - **No bearer auth required.** Anyone on the network can call `/mcp`.
   Intentional, so Smithery installs are one-click.
-- **Per-IP rate limit.** Default 120 requests/minute keyed on
-  `scope["client"][0]` (populated from `X-Forwarded-For` by uvicorn's
-  `proxy_headers=True` so it reflects the originator IP, not Fly's
-  edge address).
+- **Per-IP rate limit.** Default 300 requests/minute keyed on the
+  originator IP, resolved by `_client_ip` from the **rightmost**
+  `X-Forwarded-For` entry — specifically the Nth-from-right, where N is
+  `ESTNLTK_MCP_TRUSTED_PROXY_HOPS` (default 1, matching Fly's single edge
+  proxy). A proxy *appends* to whatever the caller sent, so the leftmost
+  entry is caller-controlled and the rightmost is not.
+
+  Until 0.5.4 this read `scope["client"][0]`, which uvicorn had rewritten
+  from the leftmost entry — so a caller could mint a fresh bucket per
+  request by varying the header and evade the limit entirely. If you run
+  this server **directly exposed**, with no proxy in front, set
+  `ESTNLTK_MCP_TRUSTED_PROXY_HOPS=0` so `X-Forwarded-For` is not trusted
+  at all and bucketing falls back to the socket peer.
 - **All other hardening preserved.** No shell exec, no fs writes, no
   token logging (no tokens to log), no telemetry, size-bounded inputs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.3"
+version = "0.5.4"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -63,8 +63,15 @@ MAX_DOC_CHARS = 500_000
 DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 
+# How many reverse proxies sit in front of this server. Used to pick the
+# trustworthy entry out of X-Forwarded-For for the public-mode per-IP rate
+# limiter — see _client_ip. Fly.io puts exactly one proxy in front, which
+# is the default. Set to 0 if the server is directly internet-exposed, so
+# that a caller-supplied XFF is never trusted.
+_TRUSTED_PROXY_HOPS = max(0, int(os.environ.get("ESTNLTK_MCP_TRUSTED_PROXY_HOPS", "1")))
+
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.3"
+SERVER_VERSION = "0.5.4"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -4400,8 +4407,43 @@ def _accept_header(scope: dict) -> str:
 
 
 def _client_ip(scope: dict) -> str:
-    """Best-effort originator IP. uvicorn(proxy_headers=True) populates
-    scope["client"] from X-Forwarded-For when running behind Fly/Smithery."""
+    """Originator IP for the public-mode per-IP rate limiter.
+
+    Reads X-Forwarded-For from the RIGHT, not the left. uvicorn runs with
+    `forwarded_allow_ips="*"` and rewrites `scope["client"]` from the
+    LEFTMOST XFF entry — which is fully caller-controlled, because a proxy
+    appends to whatever the client sent. Bucketing on that let any caller
+    mint a fresh rate-limit bucket per request simply by varying the
+    header, defeating the limiter entirely. Reproduced against a local
+    server in public mode at a 5/min limit: a fixed spoofed value gets 429
+    after five requests, while rotating the value stays 200 indefinitely.
+
+    The Nth-from-right entry is the one written by the Nth proxy in front
+    of us, and a caller cannot append after a proxy — so it is correct
+    whether the edge APPENDS to a client-supplied header or REPLACES it.
+    `_TRUSTED_PROXY_HOPS` is how many proxies we sit behind (Fly = 1).
+    Set it to 0 when the server is directly exposed, which makes XFF
+    untrusted entirely and buckets on the real peer.
+
+    Falls back to the peer address whenever XFF has fewer entries than
+    there are trusted hops, i.e. when the header is absent or too short to
+    have come through the expected chain.
+    """
+    hops = _TRUSTED_PROXY_HOPS
+    if hops > 0:
+        for raw_key, raw_val in (scope.get("headers") or []):
+            try:
+                if raw_key.decode("latin-1").lower() != "x-forwarded-for":
+                    continue
+                parts = [p.strip() for p in raw_val.decode("latin-1").split(",") if p.strip()]
+            except Exception:
+                continue
+            if len(parts) >= hops:
+                return parts[-hops]
+            break
+    # `scope["client"]` is uvicorn's parse of XFF and therefore spoofable;
+    # it is only reached when the header is missing or malformed, in which
+    # case it degrades to the true peer.
     client = scope.get("client") or ("unknown", 0)
     return client[0] if isinstance(client, (tuple, list)) and client else "unknown"
 
@@ -4703,8 +4745,14 @@ def _run_http(host: str, port: int, token: str | None, rate_limit: int, public_m
         port=port,
         log_level="info",
         access_log=False,  # keep tokens out of logs
-        proxy_headers=True,
-        forwarded_allow_ips="*",  # behind Fly/Smithery edge
+        # proxy_headers is OFF on purpose. With it on (and
+        # forwarded_allow_ips="*") uvicorn rewrites scope["client"] from the
+        # LEFTMOST X-Forwarded-For entry, which is fully caller-controlled —
+        # that is what let a caller defeat the per-IP rate limiter by
+        # varying the header. We interpret XFF ourselves in _client_ip,
+        # counting from the right, and we need scope["client"] to stay the
+        # true peer so it is a trustworthy fallback.
+        proxy_headers=False,
     )
 
 

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -1,0 +1,160 @@
+"""Tests for per-IP rate-limit bucketing (public mode).
+
+The bug these pin down: `_client_ip` returned `scope["client"][0]`, which
+uvicorn had rewritten from the LEFTMOST `X-Forwarded-For` entry. A proxy
+APPENDS to whatever the caller sent, so the leftmost entry is entirely
+caller-controlled — meaning any caller could mint a fresh rate-limit bucket
+per request just by varying the header, and the public deployment's only
+DoS protection did nothing.
+
+Reproduced before the fix against a local server in public mode at a 5/min
+limit: a fixed spoofed value got 429 after five requests, while rotating
+the value stayed 200 indefinitely.
+
+The fix reads XFF from the RIGHT. The Nth-from-right entry is the one
+written by the Nth proxy in front of us, and a caller cannot append after a
+proxy — so it is correct whether the edge appends to a client-supplied
+header or replaces it outright.
+
+Run via:
+
+    uv run python tests/test_client_ip.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server
+
+failures: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+def scope(xff: str | None = None, peer: str = "172.16.0.5") -> dict:
+    headers = []
+    if xff is not None:
+        headers.append((b"x-forwarded-for", xff.encode()))
+    # With proxy_headers=False, uvicorn leaves scope["client"] as the real
+    # peer. Tests assert against that contract.
+    return {"headers": headers, "client": (peer, 0)}
+
+
+def _with_hops(n: int):
+    class _Ctx:
+        def __enter__(self):
+            self.prev = server._TRUSTED_PROXY_HOPS
+            server._TRUSTED_PROXY_HOPS = n
+            return self
+
+        def __exit__(self, *a):
+            server._TRUSTED_PROXY_HOPS = self.prev
+            return False
+    return _Ctx()
+
+
+def one_proxy_in_front() -> None:
+    """Fly's topology: exactly one proxy, which appends the true peer."""
+    print("hops=1 (Fly): the forged prefix is ignored")
+    with _with_hops(1):
+        check("caller forged one entry",
+              server._client_ip(scope("9.9.9.9, 203.0.113.7")) == "203.0.113.7")
+        check("caller forged twenty entries",
+              server._client_ip(scope(", ".join(["1.2.3.4"] * 20) + ", 203.0.113.7"))
+              == "203.0.113.7")
+        check("edge replaced the header outright",
+              server._client_ip(scope("203.0.113.7")) == "203.0.113.7")
+        check("no XFF at all falls back to the real peer",
+              server._client_ip(scope(None, peer="198.51.100.4")) == "198.51.100.4")
+        # The whole point: rotating the forged part must NOT change the bucket.
+        buckets = {server._client_ip(scope(f"10.0.0.{i}, 203.0.113.7")) for i in range(50)}
+        check("rotating the forged prefix yields ONE bucket, not 50",
+              buckets == {"203.0.113.7"}, f"{len(buckets)} distinct: {sorted(buckets)[:4]}")
+
+
+def directly_exposed() -> None:
+    """hops=0: no proxy in front, so XFF is not trustworthy at all."""
+    print("hops=0 (direct exposure): XFF is ignored entirely")
+    with _with_hops(0):
+        check("forged XFF does not move the bucket",
+              server._client_ip(scope("203.0.113.7", peer="172.16.0.5")) == "172.16.0.5")
+        buckets = {server._client_ip(scope(f"203.0.113.{i}", peer="172.16.0.5"))
+                   for i in range(50)}
+        check("rotating XFF yields ONE bucket", buckets == {"172.16.0.5"}, str(buckets))
+
+
+def two_proxies() -> None:
+    print("hops=2 (e.g. CDN in front of the edge)")
+    with _with_hops(2):
+        check("takes the second-from-right entry",
+              server._client_ip(scope("203.0.113.7, 104.16.0.1, 66.51.0.1")) == "104.16.0.1")
+        # Fewer entries than trusted hops means the chain is not what we
+        # expect, so trust the peer rather than a caller-supplied value.
+        check("short chain falls back to the peer",
+              server._client_ip(scope("9.9.9.9", peer="172.16.0.5")) == "172.16.0.5")
+
+
+def malformed_input_is_safe() -> None:
+    print("malformed headers never raise")
+    with _with_hops(1):
+        for raw in ("", "   ", ",,,", "not-an-ip", "9.9.9.9,,203.0.113.7"):
+            try:
+                got = server._client_ip(scope(raw))
+                check(f"{raw!r} handled -> {got!r}", isinstance(got, str) and got != "")
+            except Exception as e:
+                check(f"{raw!r} handled", False, f"{type(e).__name__}: {e}")
+        # Non-UTF8 bytes in the header must not blow up the request path.
+        try:
+            s = {"headers": [(b"x-forwarded-for", b"\xff\xfe bad")], "client": ("172.16.0.5", 0)}
+            got = server._client_ip(s)
+            check("undecodable header handled", isinstance(got, str))
+        except Exception as e:
+            check("undecodable header handled", False, f"{type(e).__name__}: {e}")
+
+
+def uvicorn_does_not_rewrite_client() -> None:
+    """The fix depends on scope["client"] being the real peer, which is only
+    true with proxy_headers disabled."""
+    print("uvicorn is configured not to rewrite scope['client']")
+    import re
+    src = Path(server.__file__).read_text(encoding="utf-8")
+    check("proxy_headers=False is set", "proxy_headers=False" in src)
+    # Match the KWARG, not prose: the docstring in _client_ip mentions
+    # forwarded_allow_ips="*" to explain the bug it fixes, and that
+    # explanation should not fail its own test.
+    passed_as_kwarg = re.search(r'^\s*forwarded_allow_ips\s*=', src, re.M)
+    check("forwarded_allow_ips is not passed to uvicorn",
+          passed_as_kwarg is None,
+          "a wildcard trust would re-enable leftmost-XFF rewriting")
+    check("proxy_headers is not enabled anywhere",
+          re.search(r'^\s*proxy_headers\s*=\s*True', src, re.M) is None)
+
+
+def hops_is_configurable() -> None:
+    print("hop count is configurable and clamped")
+    check("defaults to 1 (Fly)", isinstance(server._TRUSTED_PROXY_HOPS, int))
+    check("never negative", server._TRUSTED_PROXY_HOPS >= 0)
+
+
+one_proxy_in_front()
+directly_exposed()
+two_proxies()
+malformed_input_is_safe()
+uvicorn_does_not_rewrite_client()
+hops_is_configurable()
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("\nall client-IP bucketing tests passed")

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
## The bug

`_client_ip` returned `scope["client"][0]`. uvicorn — running with `proxy_headers=True` and `forwarded_allow_ips="*"` — had rewritten that from the **leftmost** `X-Forwarded-For` entry.

A proxy *appends* to whatever the caller sent, so the leftmost entry is entirely caller-controlled. Every request carrying a different header got its own fresh rate-limit bucket. On the public deployment, which is the default posture, that is the only DoS protection there is.

## Reproduced, not theorised

Local server, public mode, limit lowered to 5/min:

```
A) fixed spoofed IP    x12: 200 200 200 200 200 429 429 429 429 429 429 429
B) rotating spoofed IP x12: 200 200 200 200 200 200 200 200 200 200 200 200
```

`SECURITY.md:73-76` claimed the limiter "reflects the originator IP, not Fly's edge address." It didn't. That text is corrected in this PR.

## The fix

Read XFF from the **right**: the Nth-from-right entry, where N is `ESTNLTK_MCP_TRUSTED_PROXY_HOPS` (default 1, matching Fly's single edge proxy). A caller cannot append after a proxy, so this is correct whether the edge appends to a client-supplied header or replaces it outright.

After, under production topology (edge appends the true peer):

```
attacker rotates the forged prefix x10: 200 200 200 200 200 429 429 429 429 429
```

**uvicorn's `proxy_headers` is now off.** This part is not incidental. The fallback needs `scope["client"]` to be the real peer — with `proxy_headers=True` it was itself derived from the leftmost XFF, so `TRUSTED_PROXY_HOPS=0` ("no proxy in front, don't trust the header") stayed fully bypassable. My first attempt shipped exactly that hole; the `hops=0` test caught it, which is why that test exists.

## Operators

If you run this server **directly exposed**, with no proxy in front, set `ESTNLTK_MCP_TRUSTED_PROXY_HOPS=0` so `X-Forwarded-For` is never trusted and bucketing falls back to the socket peer. The default of 1 is correct for the hosted Fly deployment and for anything behind a single reverse proxy.

## Tests

`tests/test_client_ip.py`, 20 checks: all three topologies (1 / 0 / 2 proxies), malformed and undecodable headers, and the specific property that matters — rotating a forged prefix yields **one** bucket, not fifty. It also asserts the uvicorn kwargs the fix depends on, matching the kwarg rather than prose so the docstring explaining the old bug doesn't fail its own test.

359 checks across 8 suites, `ruff check .` clean.

## Provenance

Surfaced while reviewing #36. The bug is ours, not the contributor's — but their nginx config prompted the question, and I've credited them in the changelog.