### PR TITLE
0.5.5: -mata attributes are indeclinable, and -tu caritives are not (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Run client-IP bucketing tests (rate-limit evasion)
         run: uv run --python ${{ matrix.python-version }} python tests/test_client_ip.py
 
+      - name: Run indeclinable-attribute tests (issue #42)
+        run: uv run --python ${{ matrix.python-version }} python tests/test_indeclinable.py
+
   # Proves the DOCUMENTED source-install path works, from a clean state.
   # The existing `smoke` job pre-fetches resources through bespoke steps and
   # exports ESTNLTK_MCP_FASTTEXT_PATH, which masks exactly the class of bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ versions follow [Semantic Versioning](https://semver.org/).
   produce *`õnnetud laste` where the correct form is `õnnetute laste`.
 
   Rather than add `-mata` to the ending list and leave that in place, the
-  check now consults Vabamorf: a frozen attributive is an adjective
-  carrying no case/number form, a declining one carries `sg n` / `pl n`
-  and lemmatises back to `-tu`. The ending list stays as a fallback,
+  check now consults Vabamorf, which separates *most* of them: a frozen
+  attributive has an adjective reading carrying no case/number form, a
+  declining one only ever carries `sg n` / `pl n`. Not all — see Known
+  limits below. The ending list stays as a fallback,
   because Vabamorf sometimes misanalyses these as nouns (`hajutatud` →
   `S/pl n/hajutatu`) and the ending is correct there.
 
@@ -47,6 +48,17 @@ versions follow [Semantic Versioning](https://semver.org/).
   predicted this class ("a handful of non-participle words end in
   `-mata`") and they were right.
 
+- **Ordinary plural nouns were being frozen too, and that was the worst of
+  the three.** Any Estonian noun whose nominative plural ends `-tud`,
+  `-dud` or `-nud` hit the ending test: `raamatud`, `linnud`, `laenud`,
+  `kohtud`, `toidud`, `säästud`. An agent following the documented
+  contract would write *`paksude raamatud` for `paksude raamatute`. This
+  predates #42, but it sits in the same code path and the fix is the same
+  shape: the lemma separates them, because Vabamorf's misanalysed
+  participles lemmatise to a deverbal stem (`hajutatud` → `hajutatu`)
+  while an ordinary plural does not (`raamatud` → `raamat`). The ending
+  fallback now requires a deverbal lemma.
+
 - **The verdict no longer depends on Vabamorf's analysis ordering.** A
   participle like `tuntud` comes back as `A/''`, `V/tud`, `A/pl n` and
   `A/sg n`; reading only the first analysis meant a reordering upstream
@@ -54,6 +66,20 @@ versions follow [Semantic Versioning](https://semver.org/).
   with no case/number form is enough to freeze the word. The probe is also
   looked up from the lowercased word, so capitalisation cannot change the
   answer (`Täitmata` analysed as `H/sg n` where `täitmata` is `V/mata`).
+  Without this, `lugupeetud` — the standard salutation in Estonian
+  official correspondence — reported as declinable.
+
+### Known limits
+
+Stated here because the morphology cannot resolve them, and the tests
+assert them so the documentation and the behaviour stay in step:
+
+- A caritive whose lemma ends `-tu` and which Vabamorf tags only as a noun
+  (`korratud` → `korratu`, `maitsetud`) is still frozen. That lemma is
+  indistinguishable from a deverbal `hajutatu`.
+- Where the caritive plural and the participle are the same string
+  (`nõutud`, `kaalutud`, `kohatud`), the participle reading wins.
+  Separating them needs semantics, not morphology.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,25 @@ versions follow [Semantic Versioning](https://semver.org/).
   because Vabamorf sometimes misanalyses these as nouns (`hajutatud` →
   `S/pl n/hajutatu`) and the ending is correct there.
 
-  `analyze_morphology` passes the analysis it already has, so the hot path
+  `analyze_morphology` passes the analyses it already has, so the hot path
   costs nothing extra; other callers get a cached lookup.
+
+- **A second `-mata` trap, caught while self-reviewing this fix.** A noun
+  whose stem ends in `-ma` forms its abessive in `-mata`: `teema` →
+  `teemata`, `kliima` → `kliimata`, `draama` → `draamata`. Those are
+  inflected nouns, not the `mata`-form, so simply adding `mata` to the
+  ending list froze them. The check now declines anything with an
+  abessive reading before the ending fallback runs. The issue author
+  predicted this class ("a handful of non-participle words end in
+  `-mata`") and they were right.
+
+- **The verdict no longer depends on Vabamorf's analysis ordering.** A
+  participle like `tuntud` comes back as `A/''`, `V/tud`, `A/pl n` and
+  `A/sg n`; reading only the first analysis meant a reordering upstream
+  could silently flip it. All adjective readings are considered, and one
+  with no case/number form is enough to freeze the word. The probe is also
+  looked up from the lowercased word, so capitalisation cannot change the
+  answer (`Täitmata` analysed as `H/sg n` where `täitmata` is `V/mata`).
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.5] — 2026-08-23
+
+### Fixed
+
+- **`analyze_morphology` reported `-mata` attributes as declinable**
+  ([#42](https://github.com/silly-geese/estonian-mcp/issues/42), reported
+  by @tomkabel with the normative citations). The `-mata` form is the
+  tud-participle's negative counterpart and EKI states it "jääb alati
+  käändumatuks": `täitmata lepingute reserv`, not *täitmatute. The ending
+  test listed only `-tud`/`-dud`/`-nud`, so every `-mata` attribute came
+  back `indeclinable: false`, nudging a consumer toward the non-standard
+  declined form. This bites hardest in the legal and administrative
+  register the editorial tools target, where `-mata` is everywhere.
+
+- **`-tu` caritive adjectives were frozen when they should agree.** Not
+  reported, but the reporter's own EKI citation points at it: `-tu`
+  caritives DO agree, and their nominative plural also ends in `-tud`
+  (`õnnetu` → `õnnetud`, `lugematu` → `lugematud`). An ending test cannot
+  tell those from participles, so it marked them invariant, which would
+  produce *`õnnetud laste` where the correct form is `õnnetute laste`.
+
+  Rather than add `-mata` to the ending list and leave that in place, the
+  check now consults Vabamorf: a frozen attributive is an adjective
+  carrying no case/number form, a declining one carries `sg n` / `pl n`
+  and lemmatises back to `-tu`. The ending list stays as a fallback,
+  because Vabamorf sometimes misanalyses these as nouns (`hajutatud` →
+  `S/pl n/hajutatu`) and the ending is correct there.
+
+  `analyze_morphology` passes the analysis it already has, so the hot path
+  costs nothing extra; other callers get a cached lookup.
+
+### Notes
+
+- The `inflection_et` benchmark is **unchanged at 96.5% first-candidate /
+  99.1% any-candidate**, and that is not a coincidence worth trusting: its
+  200 noun phrases contain zero `-mata` attributes and no `-tu` caritive
+  plurals, so it exercises neither defect and could not have caught either.
+  `tests/test_indeclinable.py` is what guards this now.
+
 ## [0.5.4] — 2026-08-23
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.4"
+version = "0.5.5"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -1187,19 +1187,21 @@ _INDECLINABLE_ADJ_ET: frozenset[str] = frozenset({
 })
 
 
-# Endings that mark an attributive as invariant when Vabamorf gives us no
-# usable analysis. -mata is the tud-participle's negative form (issue #42);
-# EKI: "mata-vorm jaab alati kaandumatuks".
-_INDECLINABLE_ATTR_ENDINGS: tuple[str, ...] = ("tud", "dud", "nud", "mata")
+# Lemma endings that mark a -tud/-dud/-nud surface form as genuinely
+# deverbal. Needed because Vabamorf misanalyses some participles as nouns
+# (hajutatud -> S/pl n, lemma `hajutatu`), and the ending alone cannot tell
+# those from an ordinary plural noun that happens to end the same way
+# (raamatud -> lemma `raamat`, linnud -> `lind`).
+_DEVERBAL_LEMMA_ENDINGS: tuple[str, ...] = ("tu", "nu", "du", "tud", "nud", "dud")
 
 
 @lru_cache(maxsize=4096)
-def _attr_analyses(word: str) -> tuple[tuple[str, str], ...]:
-    """Every (partofspeech, form) pair Vabamorf offers for a word in
-    isolation.
+def _attr_analyses(word: str) -> tuple[tuple[str, str, str], ...]:
+    """Every (partofspeech, form, lemma) triple Vabamorf offers for a word
+    in isolation.
 
     ALL analyses, not just the first: a participle like `tuntud` comes back
-    as A/'', V/tud, A/pl n and A/sg n, and picking index 0 would make the
+    as A/'', V/tud, A/pl n and A/sg n, so picking index 0 would make the
     verdict depend on Vabamorf's ordering. Cached, because callers hit the
     same attributes repeatedly; only consulted when the caller has no
     analysis of its own to pass in.
@@ -1214,17 +1216,19 @@ def _attr_analyses(word: str) -> tuple[tuple[str, str], ...]:
         if not spans:
             return ()
         span = spans[0]
-        poss, forms = list(span.partofspeech), list(span.form)
-        # strict=False on purpose: if Vabamorf ever returns mismatched
-        # list lengths, truncating is far better than raising inside a
-        # tool call over a morphology detail.
-        return tuple((p or "", f or "") for p, f in zip(poss, forms, strict=False))
+        # strict=False on purpose: if Vabamorf ever returns mismatched list
+        # lengths, truncating beats raising inside a tool call over a
+        # morphology detail.
+        return tuple(
+            (p or "", f or "", (lm or "").lower())
+            for p, f, lm in zip(span.partofspeech, span.form, span.lemma, strict=False)
+        )
     except Exception:
         return ()
 
 
 def _is_indeclinable_attr(
-    word: str, analyses: tuple[tuple[str, str], ...] | None = None
+    word: str, analyses: tuple[tuple[str, str, str], ...] | None = None
 ) -> bool:
     """True if a word does NOT inflect when used attributively (before a
     noun), so adjective-noun agreement should leave it in base form.
@@ -1237,22 +1241,30 @@ def _is_indeclinable_attr(
       states "jaab alati kaandumatuks": `taitmata lepingute reserv`, not
       *taitmatute. Issue #42.
 
-    WHY THIS IS NOT AN ENDING TEST. Two traps an ending test walks into:
+    WHY THIS IS NOT AN ENDING TEST. Three traps an ending test walks into:
 
     1. -tu caritive adjectives DO agree, and their nominative plural also
-       ends in -tud: `onnetu` -> `onnetud`, `lugematu` -> `lugematud`.
-       Freezing those yields *`onnetud laste` for `onnetute laste`.
-    2. A noun whose stem ends in -ma forms its abessive in -mata:
-       `teema` -> `teemata`, `kliima` -> `kliimata`. Those are inflected
-       nouns, not the mata-form.
+       ends in -tud: `onnetu` -> `onnetud`. Freezing those yields
+       *`onnetud laste` for `onnetute laste`.
+    2. Ordinary plural nouns end the same way: `raamatud` (raamat),
+       `linnud` (lind), `kohtud` (kohus). Freezing those is worse still,
+       since they are common words.
+    3. A noun whose stem ends in -ma forms its abessive in -mata:
+       `teema` -> `teemata`. That is an inflected noun, not the mata-form.
 
-    So: if any analysis is an adjective, trust morphology -- an invariant
-    attributive has an adjective reading with NO case/number form, while a
-    declining one only ever carries `sg n` / `pl n`. Otherwise, an
-    abessive reading means trap 2 and we decline. Only with no usable
-    analysis do we fall back to the ending, which still matters because
-    Vabamorf sometimes misanalyses a participle as a noun
-    (`hajutatud` -> S/pl n/`hajutatu`) and the ending is right there.
+    So the order is: an adjective reading decides it (an invariant
+    attributive has one with NO case/number form, a declining one only
+    ever carries `sg n` / `pl n`); then -mata is invariant unless it is a
+    NOUN abessive; then -tud/-dud/-nud is invariant only when some lemma
+    looks deverbal, which separates `hajutatu` from `raamat`.
+
+    KNOWN LIMITS, stated because the ending cannot resolve them:
+    - Caritives whose lemma ends -tu and which Vabamorf tags only as a
+      noun (`korratud` -> `korratu`, `maitsetud`) are still frozen; the
+      lemma is indistinguishable from a deverbal `hajutatu`.
+    - Homographs where the caritive plural and the participle are the same
+      string (`noutud`, `kaalutud`, `kohatud`) resolve to the participle
+      reading. Disambiguating needs semantics, not morphology.
 
     `analyses` may be supplied by a caller that already has them, to avoid
     a second pass; when omitted they are looked up from the LOWERCASED
@@ -1267,12 +1279,26 @@ def _is_indeclinable_attr(
     if analyses is None:
         analyses = _attr_analyses(w)
 
-    adjective_readings = [f for p, f in analyses if p == "A"]
+    adjective_readings = [f for p, f, _lm in analyses if p == "A"]
     if adjective_readings:
         return any(not (f or "").strip() for f in adjective_readings)
-    if any((f or "").endswith("ab") for _p, f in analyses):
-        return False
-    return w.endswith(_INDECLINABLE_ATTR_ENDINGS)
+
+    if w.endswith("mata"):
+        # Trap 3. Only a NOUN abessive is an inflected form here; the
+        # guesser also emits spurious abessive readings under other tags
+        # for real mata-forms (`voltsimata` -> C/sg ab).
+        return not any(
+            p == "S" and (f or "").endswith("ab") for p, f, _lm in analyses
+        )
+
+    if w.endswith(("tud", "dud", "nud")):
+        # Trap 2. Vabamorf misanalyses some participles as nouns, so the
+        # ending still has work to do -- but only when a lemma looks
+        # deverbal. `hajutatu` yes, `raamat` no.
+        return any(
+            lm.endswith(_DEVERBAL_LEMMA_ENDINGS) for _p, _f, lm in analyses
+        )
+    return False
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1329,7 +1355,9 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
         is_ambiguous = analyses_count > 1
         code, et = _usage_note(_first(lemmas), _first(pos))
         indeclinable = _is_indeclinable_attr(
-            word, tuple((p or "", f or "") for p, f in zip(pos, forms, strict=False)))
+            word,
+            tuple((p or "", f or "", (lm or "").lower())
+                  for p, f, lm in zip(pos, forms, lemmas, strict=False)))
         if all_analyses:
             analyses = [
                 {

--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 _TRUSTED_PROXY_HOPS = max(0, int(os.environ.get("ESTNLTK_MCP_TRUSTED_PROXY_HOPS", "1")))
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.4"
+SERVER_VERSION = "0.5.5"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -1187,24 +1187,76 @@ _INDECLINABLE_ADJ_ET: frozenset[str] = frozenset({
 })
 
 
-def _is_indeclinable_attr(word: str) -> bool:
+# Endings that mark an attributive as invariant when Vabamorf gives us no
+# usable adjective analysis. -mata is the tud-participle's negative form
+# (issue #42); EKI: "mata-vorm jääb alati käändumatuks".
+_INDECLINABLE_ATTR_ENDINGS: tuple[str, ...] = ("tud", "dud", "nud", "mata")
+
+
+@lru_cache(maxsize=4096)
+def _attr_morphology(word: str) -> tuple[str, str]:
+    """(partofspeech, form) for a single word in isolation, via Vabamorf.
+
+    Cached because callers hit the same attributes repeatedly and this is
+    only consulted when the caller has no analysis of its own to pass in.
+    Returns ("", "") if the word cannot be analysed, which makes the caller
+    fall back to the ending heuristic.
+    """
+    try:
+        t = _Text()(word)
+        t.tag_layer(["morph_analysis"])
+        spans = list(t.morph_analysis)
+        if not spans:
+            return ("", "")
+        pos, form, _lemma = _span_bits(spans[0])
+        return (pos, form)
+    except Exception:
+        return ("", "")
+
+
+def _is_indeclinable_attr(
+    word: str, pos: str | None = None, form: str | None = None
+) -> bool:
     """True if a word does NOT inflect when used attributively (before a
     noun), so adjective-noun agreement should leave it in base form.
 
-    Two cases, both verified against TalTech's inflection_et benchmark:
+    Three cases:
     - lexical indeclinables (täis, eri, väärt, ...)
-    - past participles in -tud / -dud / -nud, which are invariant in
-      attributive position (`tuntud laulja` → `tuntud laulja` in the
-      genitive, not *tuntu laulja). Detected by ending because Vabamorf
-      often misanalyses them (e.g. hajutatud → noun 'hajutatu').
+    - past participles in -tud / -dud / -nud, invariant as an eestäiend
+      (`tuntud laulja` stays `tuntud laulja` in the genitive, not
+      *tuntu laulja)
+    - the -mata form, the tud-participle's negative counterpart, which EKI
+      states "jääb alati käändumatuks": `täitmata lepingute reserv`, not
+      *täitmatute. Reported as issue #42.
 
-    NOT flagged: -v present participles (rahuldav → rahuldava), which do
+    THE -tu TRAP. An ending test alone cannot do this correctly, because
+    -tu caritive adjectives DO agree and their nominative plural also ends
+    in -tud: `õnnetu` → `õnnetud`, `lugematu` → `lugematud`. Treating those
+    as invariant produced *`õnnetud laste` instead of `õnnetute laste`.
+    Vabamorf separates the two cleanly: a frozen attributive is tagged as
+    an adjective carrying NO case/number form, while a declining one
+    carries `sg n` / `pl n` and lemmatises back to -tu.
+
+    So when the word analyses as an adjective we trust the form field, and
+    otherwise fall back to the ending. The fallback matters: Vabamorf
+    sometimes misanalyses these as nouns (`hajutatud` → S/pl n/`hajutatu`),
+    and the ending is right in that case.
+
+    `pos` and `form` may be supplied by a caller that already has the
+    analysis, to avoid a second pass; when omitted they are looked up.
+
+    NOT flagged: -v present participles (rahuldav → rahuldava), which
     agree normally.
     """
     w = word.lower()
     if w in _INDECLINABLE_ADJ_ET:
         return True
-    return w.endswith(("tud", "dud", "nud"))
+    if pos is None and form is None:
+        pos, form = _attr_morphology(word)
+    if (pos or "") == "A":
+        # Adjective with a case/number form => it declines.
+        return not (form or "").strip()
+    return w.endswith(_INDECLINABLE_ATTR_ENDINGS)
 
 
 @mcp.tool(annotations=ToolAnnotations(
@@ -1260,7 +1312,8 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
         analyses_count = len(lemmas)
         is_ambiguous = analyses_count > 1
         code, et = _usage_note(_first(lemmas), _first(pos))
-        indeclinable = _is_indeclinable_attr(word)
+        indeclinable = _is_indeclinable_attr(
+            word, _first(pos) or "", _first(forms) or "")
         if all_analyses:
             analyses = [
                 {

--- a/server.py
+++ b/server.py
@@ -1234,23 +1234,23 @@ def _is_indeclinable_attr(
     noun), so adjective-noun agreement should leave it in base form.
 
     Three invariant classes:
-    - lexical indeclinables (tais, eri, vaart, ...)
+    - lexical indeclinables (täis, eri, väärt, ...)
     - past participles in -tud / -dud / -nud (`tuntud laulja` stays
       `tuntud` in the genitive, not *tuntu laulja)
     - the -mata form, the tud-participle's negative counterpart, which EKI
-      states "jaab alati kaandumatuks": `taitmata lepingute reserv`, not
-      *taitmatute. Issue #42.
+      states "jääb alati käändumatuks": `täitmata lepingute reserv`, not
+      *täitmatute. Issue #42.
 
     WHY THIS IS NOT AN ENDING TEST. Three traps an ending test walks into:
 
     1. -tu caritive adjectives DO agree, and their nominative plural also
-       ends in -tud: `onnetu` -> `onnetud`. Freezing those yields
-       *`onnetud laste` for `onnetute laste`.
+       ends in -tud: `õnnetu` → `õnnetud`. Freezing those yields
+       *`õnnetud laste` for `õnnetute laste`.
     2. Ordinary plural nouns end the same way: `raamatud` (raamat),
        `linnud` (lind), `kohtud` (kohus). Freezing those is worse still,
        since they are common words.
     3. A noun whose stem ends in -ma forms its abessive in -mata:
-       `teema` -> `teemata`. That is an inflected noun, not the mata-form.
+       `teema` → `teemata`. That is an inflected noun, not the mata-form.
 
     So the order is: an adjective reading decides it (an invariant
     attributive has one with NO case/number form, a declining one only
@@ -1258,13 +1258,28 @@ def _is_indeclinable_attr(
     NOUN abessive; then -tud/-dud/-nud is invariant only when some lemma
     looks deverbal, which separates `hajutatu` from `raamat`.
 
-    KNOWN LIMITS, stated because the ending cannot resolve them:
-    - Caritives whose lemma ends -tu and which Vabamorf tags only as a
-      noun (`korratud` -> `korratu`, `maitsetud`) are still frozen; the
-      lemma is indistinguishable from a deverbal `hajutatu`.
+    KNOWN LIMITS, stated because the morphology cannot resolve them:
+
+    - A caritive whose lemma ends -tu and which Vabamorf tags ONLY as a
+      noun (`töötud` → `töötu`, `korratud`, `maitsetud`) is still frozen.
+      That lemma is shaped exactly like the deverbal `hajutatu`, and no
+      suffix test separates them. Checking whether a matching verb exists
+      is worse, not better: it breaks `lugupeetud` and `mahajäetud` while
+      falsely firing on `kasutud` and `raamatud`.
     - Homographs where the caritive plural and the participle are the same
-      string (`noutud`, `kaalutud`, `kohatud`) resolve to the participle
-      reading. Disambiguating needs semantics, not morphology.
+      string cannot be resolved at all, and they fail in BOTH directions
+      depending on which readings Vabamorf offers: `nõutud` and `kaalutud`
+      have an A/'' reading and freeze, while a word Vabamorf knows only as
+      a caritive declines even where the participle sense was meant.
+      Disambiguating needs semantics, not morphology.
+
+    CONTEXT BEATS ISOLATION, and callers differ. `analyze_morphology`
+    supplies analyses disambiguated from the SENTENCE, which resolves most
+    of the first class correctly: `töötud inimesed` gives A/pl n and
+    declines, where the same word alone gives S/pl n and freezes. The
+    isolated lookup is a best-effort fallback for callers that have no
+    sentence, so the two can disagree on exactly those ambiguous words.
+    Prefer passing analyses when you have them.
 
     `analyses` may be supplied by a caller that already has them, to avoid
     a second pass; when omitted they are looked up from the LOWERCASED
@@ -1286,7 +1301,7 @@ def _is_indeclinable_attr(
     if w.endswith("mata"):
         # Trap 3. Only a NOUN abessive is an inflected form here; the
         # guesser also emits spurious abessive readings under other tags
-        # for real mata-forms (`voltsimata` -> C/sg ab).
+        # for real mata-forms (`võltsimata` → C/sg ab).
         return not any(
             p == "S" and (f or "").endswith("ab") for p, f, _lm in analyses
         )

--- a/server.py
+++ b/server.py
@@ -1188,74 +1188,90 @@ _INDECLINABLE_ADJ_ET: frozenset[str] = frozenset({
 
 
 # Endings that mark an attributive as invariant when Vabamorf gives us no
-# usable adjective analysis. -mata is the tud-participle's negative form
-# (issue #42); EKI: "mata-vorm jääb alati käändumatuks".
+# usable analysis. -mata is the tud-participle's negative form (issue #42);
+# EKI: "mata-vorm jaab alati kaandumatuks".
 _INDECLINABLE_ATTR_ENDINGS: tuple[str, ...] = ("tud", "dud", "nud", "mata")
 
 
 @lru_cache(maxsize=4096)
-def _attr_morphology(word: str) -> tuple[str, str]:
-    """(partofspeech, form) for a single word in isolation, via Vabamorf.
+def _attr_analyses(word: str) -> tuple[tuple[str, str], ...]:
+    """Every (partofspeech, form) pair Vabamorf offers for a word in
+    isolation.
 
-    Cached because callers hit the same attributes repeatedly and this is
-    only consulted when the caller has no analysis of its own to pass in.
-    Returns ("", "") if the word cannot be analysed, which makes the caller
-    fall back to the ending heuristic.
+    ALL analyses, not just the first: a participle like `tuntud` comes back
+    as A/'', V/tud, A/pl n and A/sg n, and picking index 0 would make the
+    verdict depend on Vabamorf's ordering. Cached, because callers hit the
+    same attributes repeatedly; only consulted when the caller has no
+    analysis of its own to pass in.
+
+    Returns () if the word cannot be analysed, which sends the caller to
+    the ending heuristic.
     """
     try:
         t = _Text()(word)
         t.tag_layer(["morph_analysis"])
         spans = list(t.morph_analysis)
         if not spans:
-            return ("", "")
-        pos, form, _lemma = _span_bits(spans[0])
-        return (pos, form)
+            return ()
+        span = spans[0]
+        poss, forms = list(span.partofspeech), list(span.form)
+        # strict=False on purpose: if Vabamorf ever returns mismatched
+        # list lengths, truncating is far better than raising inside a
+        # tool call over a morphology detail.
+        return tuple((p or "", f or "") for p, f in zip(poss, forms, strict=False))
     except Exception:
-        return ("", "")
+        return ()
 
 
 def _is_indeclinable_attr(
-    word: str, pos: str | None = None, form: str | None = None
+    word: str, analyses: tuple[tuple[str, str], ...] | None = None
 ) -> bool:
     """True if a word does NOT inflect when used attributively (before a
     noun), so adjective-noun agreement should leave it in base form.
 
-    Three cases:
-    - lexical indeclinables (täis, eri, väärt, ...)
-    - past participles in -tud / -dud / -nud, invariant as an eestäiend
-      (`tuntud laulja` stays `tuntud laulja` in the genitive, not
-      *tuntu laulja)
+    Three invariant classes:
+    - lexical indeclinables (tais, eri, vaart, ...)
+    - past participles in -tud / -dud / -nud (`tuntud laulja` stays
+      `tuntud` in the genitive, not *tuntu laulja)
     - the -mata form, the tud-participle's negative counterpart, which EKI
-      states "jääb alati käändumatuks": `täitmata lepingute reserv`, not
-      *täitmatute. Reported as issue #42.
+      states "jaab alati kaandumatuks": `taitmata lepingute reserv`, not
+      *taitmatute. Issue #42.
 
-    THE -tu TRAP. An ending test alone cannot do this correctly, because
-    -tu caritive adjectives DO agree and their nominative plural also ends
-    in -tud: `õnnetu` → `õnnetud`, `lugematu` → `lugematud`. Treating those
-    as invariant produced *`õnnetud laste` instead of `õnnetute laste`.
-    Vabamorf separates the two cleanly: a frozen attributive is tagged as
-    an adjective carrying NO case/number form, while a declining one
-    carries `sg n` / `pl n` and lemmatises back to -tu.
+    WHY THIS IS NOT AN ENDING TEST. Two traps an ending test walks into:
 
-    So when the word analyses as an adjective we trust the form field, and
-    otherwise fall back to the ending. The fallback matters: Vabamorf
-    sometimes misanalyses these as nouns (`hajutatud` → S/pl n/`hajutatu`),
-    and the ending is right in that case.
+    1. -tu caritive adjectives DO agree, and their nominative plural also
+       ends in -tud: `onnetu` -> `onnetud`, `lugematu` -> `lugematud`.
+       Freezing those yields *`onnetud laste` for `onnetute laste`.
+    2. A noun whose stem ends in -ma forms its abessive in -mata:
+       `teema` -> `teemata`, `kliima` -> `kliimata`. Those are inflected
+       nouns, not the mata-form.
 
-    `pos` and `form` may be supplied by a caller that already has the
-    analysis, to avoid a second pass; when omitted they are looked up.
+    So: if any analysis is an adjective, trust morphology -- an invariant
+    attributive has an adjective reading with NO case/number form, while a
+    declining one only ever carries `sg n` / `pl n`. Otherwise, an
+    abessive reading means trap 2 and we decline. Only with no usable
+    analysis do we fall back to the ending, which still matters because
+    Vabamorf sometimes misanalyses a participle as a noun
+    (`hajutatud` -> S/pl n/`hajutatu`) and the ending is right there.
 
-    NOT flagged: -v present participles (rahuldav → rahuldava), which
+    `analyses` may be supplied by a caller that already has them, to avoid
+    a second pass; when omitted they are looked up from the LOWERCASED
+    word, so the verdict does not depend on incidental capitalisation.
+
+    NOT flagged: -v present participles (rahuldav -> rahuldava), which
     agree normally.
     """
     w = word.lower()
     if w in _INDECLINABLE_ADJ_ET:
         return True
-    if pos is None and form is None:
-        pos, form = _attr_morphology(word)
-    if (pos or "") == "A":
-        # Adjective with a case/number form => it declines.
-        return not (form or "").strip()
+    if analyses is None:
+        analyses = _attr_analyses(w)
+
+    adjective_readings = [f for p, f in analyses if p == "A"]
+    if adjective_readings:
+        return any(not (f or "").strip() for f in adjective_readings)
+    if any((f or "").endswith("ab") for _p, f in analyses):
+        return False
     return w.endswith(_INDECLINABLE_ATTR_ENDINGS)
 
 
@@ -1288,9 +1304,9 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
         same flag (quote this verbatim in Estonian replies; do NOT
         translate the English usage_note yourself)
       - indeclinable: True for words that stay in base form when used
-        attributively (lexical indeclinables like `täis`, and -tud/-nud
-        past participles like `tuntud`) — i.e. they do NOT take the
-        noun's case ending in agreement. Use this before inflecting a
+        attributively (lexical indeclinables like `täis`, -tud/-nud past
+        participles like `tuntud`, and the -mata form like `täitmata`)
+        — i.e. they do NOT take the noun's case ending in agreement. Use this before inflecting a
         noun phrase so you don't wrongly decline an invariant adjective.
 
     Input is capped at 100,000 characters.
@@ -1313,7 +1329,7 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
         is_ambiguous = analyses_count > 1
         code, et = _usage_note(_first(lemmas), _first(pos))
         indeclinable = _is_indeclinable_attr(
-            word, _first(pos) or "", _first(forms) or "")
+            word, tuple((p or "", f or "") for p, f in zip(pos, forms, strict=False)))
         if all_analyses:
             analyses = [
                 {

--- a/tests/test_indeclinable.py
+++ b/tests/test_indeclinable.py
@@ -73,14 +73,22 @@ def participles_unchanged() -> None:
     """The behaviour that was already correct must stay correct."""
     print("participles remain indeclinable")
     for w in ("tuntud", "ettenähtud", "läbimõeldud", "rafineeritud",
-              "surnud", "närbunud", "hajutatud"):
+              "surnud", "närbunud", "hajutatud",
+              # Regressions an ordering-dependent lookup introduced;
+              # lugupeetud is the standard Estonian salutation.
+              "lugupeetud", "mahajäetud", "joobnud", "väljavenitatud"):
         check(f"{w}", server._is_indeclinable_attr(w) is True)
     # hajutatud is the documented Vabamorf misanalysis (S/pl n/hajutatu).
     # It must come out True via the ending fallback, not the adjective path.
-    analyses = server._attr_analyses("hajutatud")
-    check("hajutatud is still misanalysed as a noun (fallback is exercised)",
-          not any(p == "A" for p, _f in analyses),
-          f"{analyses} — if an 'A' reading appears, the fallback is untested here")
+    # Exercise the fallback directly rather than asserting on Vabamorf's
+    # current tagging: a pinned-version canary turns CI red on an upstream
+    # bump even when this code is still correct.
+    check("noun-tagged participle still freezes (fallback path)",
+          server._is_indeclinable_attr(
+              "hajutatud", (("S", "pl n", "hajutatu"),)) is True)
+    check("noun-tagged ordinary plural does not (same path, real lemma)",
+          server._is_indeclinable_attr(
+              "raamatud", (("S", "pl n", "raamat"),)) is False)
 
 
 def ordinary_adjectives_and_lexical_indeclinables() -> None:
@@ -94,37 +102,94 @@ def ordinary_adjectives_and_lexical_indeclinables() -> None:
 def caller_supplied_analyses() -> None:
     """analyze_morphology passes the analyses it already has, to avoid a
     second Vabamorf pass. Both paths must agree."""
-    print("caller-supplied analyses match the looked-up answer")
-    for w in ("täitmata", "tuntud", "õnnetud", "suur", "teemata"):
-        supplied = server._is_indeclinable_attr(w, server._attr_analyses(w))
-        looked_up = server._is_indeclinable_attr(w)
-        check(f"{w}: supplied == looked up ({supplied})", supplied == looked_up,
-              f"supplied={supplied} looked_up={looked_up}")
+    print("in-context verdict matches the isolated one")
+    # Comparing _is_indeclinable_attr(w, _attr_analyses(w)) against
+    # _is_indeclinable_attr(w) would be the same computation twice and
+    # could not fail. analyze_morphology derives its analyses from SENTENCE
+    # CONTEXT, so this is the comparison that can actually catch a
+    # divergence between the two callers.
+    SENTENCES = [
+        ("Täitmata kohustused jäid sahtlisse.", "Täitmata"),
+        ("Saatsin kirja lugupeetud kolleegile.", "lugupeetud"),
+        ("Õnnetud lapsed said abi.", "Õnnetud"),
+        ("Haruldased linnud lendasid üle.", "linnud"),
+        ("Suur maja seisis tänaval.", "Suur"),
+    ]
+    for sentence, target in SENTENCES:
+        toks = {t["word"]: t["indeclinable"]
+                for t in server.analyze_morphology(sentence)}
+        in_context = toks[target]
+        isolated = server._is_indeclinable_attr(target)
+        check(f"{target!r}: context={in_context} isolated={isolated}",
+              in_context == isolated,
+              f"the two callers disagree for {target!r}")
 
     # Only adjective readings with a case/number form => it declines.
     check("A/'pl n' alone declines even with a -tud ending",
-          server._is_indeclinable_attr("õnnetud", (("A", "pl n"),)) is False)
+          server._is_indeclinable_attr("õnnetud", (("A", "pl n", "õnnetu"),)) is False)
     check("an A/'' reading anywhere freezes it",
-          server._is_indeclinable_attr("tuntud", (("A", "pl n"), ("A", ""))) is True)
+          server._is_indeclinable_attr(
+              "tuntud", (("A", "pl n", "tuntud"), ("A", "", "tuntud"))) is True)
     # Ordering must not decide the verdict — that was the fragility of
     # taking only Vabamorf's first analysis.
     check("verdict is order-independent",
-          server._is_indeclinable_attr("tuntud", (("A", ""), ("V", "tud"))) ==
-          server._is_indeclinable_attr("tuntud", (("V", "tud"), ("A", ""))))
+          server._is_indeclinable_attr("tuntud", (("A", "", "tuntud"), ("V", "tud", "tundma")))
+          == server._is_indeclinable_attr("tuntud", (("V", "tud", "tundma"), ("A", "", "tuntud"))))
     # A lexical indeclinable wins regardless of what morphology says.
     check("lexical list beats supplied analyses",
-          server._is_indeclinable_attr("täis", (("A", "sg n"),)) is True)
+          server._is_indeclinable_attr("täis", (("A", "sg n", "täis"),)) is True)
 
 
 def abessive_nouns_are_not_frozen() -> None:
-    """A noun whose stem ends in -ma forms its abessive in -mata
-    (teema -> teemata). Adding 'mata' to the ending list froze those; the
-    abessive guard is what stops it."""
+    """Estonian abessive is genitive + -ta, so a noun whose genitive ends
+    in -ma produces a genuine -mata form: teema -> teemata. Those are
+    inflected nouns, not the mata-form, and adding 'mata' to the ending
+    list froze them.
+
+    Only -ma stems qualify. `skeem` gives `skeemita`, not *skeemata, so
+    strings like that are guesser artifacts rather than Estonian words and
+    are deliberately not asserted on here."""
     print("-mata abessive nouns still decline")
-    for w in ("teemata", "kliimata", "draamata", "skeemata", "reklaamata"):
-        check(f"{w} (abessive of a -ma stem)",
+    for w in ("teemata", "kliimata", "draamata"):
+        check(f"{w} (genuine abessive of a -ma stem)",
               server._is_indeclinable_attr(w) is False,
               "the -mata ending must not freeze an inflected noun")
+    # ...while a real mata-form that the guesser also tags abessive must
+    # survive. The guard is narrowed to NOUN abessives for exactly this.
+    for w in ("võltsimata", "kontrollimata"):
+        check(f"{w} (real mata-form, guesser also offers an abessive)",
+              server._is_indeclinable_attr(w) is True)
+
+
+def ordinary_plural_nouns_are_not_frozen() -> None:
+    """Any Estonian noun whose nominative plural ends -tud/-dud/-nud was
+    frozen by the bare ending test: raamatud, linnud, kohtud. An agent
+    following that would write *`paksude raamatud` for `paksude
+    raamatute`. The lemma check separates them: `hajutatu` is deverbal,
+    `raamat` is not."""
+    print("ordinary plural nouns still decline")
+    for w in ("raamatud", "linnud", "laenud", "kohtud", "toidud",
+              "säästud", "juustud", "sõidud"):
+        check(f"{w}", server._is_indeclinable_attr(w) is False,
+              "an ordinary plural noun must not be frozen")
+    got = {t["word"]: t["indeclinable"]
+           for t in server.analyze_morphology("haruldased linnud lendasid")}
+    check(f"in context: {got}", got.get("linnud") is False, str(got))
+
+
+def known_limits_are_documented() -> None:
+    """These stay frozen and the docstring says so. Asserted to keep the
+    documented behaviour and the real behaviour in step: if a future change
+    fixes them, this test fails and the docstring gets updated with it."""
+    print("documented known limits")
+    for w in ("korratud", "maitsetud"):
+        check(f"{w}: caritive whose lemma is indistinguishable from deverbal",
+              server._is_indeclinable_attr(w) is True,
+              "documented limit — lemma -tu matches both classes")
+    for w in ("nõutud", "kaalutud"):
+        check(f"{w}: participle/caritive homograph resolves to the participle",
+              server._is_indeclinable_attr(w) is True,
+              "documented limit — needs semantics, not morphology")
 
 
 def end_to_end_through_the_tool() -> None:
@@ -166,6 +231,8 @@ participles_unchanged()
 ordinary_adjectives_and_lexical_indeclinables()
 caller_supplied_analyses()
 abessive_nouns_are_not_frozen()
+ordinary_plural_nouns_are_not_frozen()
+known_limits_are_documented()
 end_to_end_through_the_tool()
 probe_is_cached_and_safe()
 

--- a/tests/test_indeclinable.py
+++ b/tests/test_indeclinable.py
@@ -1,0 +1,152 @@
+"""Tests for attributive indeclinability (issue #42).
+
+`_is_indeclinable_attr` decides whether an attribute stays in base form
+under adjective-noun agreement. Two defects are pinned here.
+
+1. The reported one: the `-mata` form was omitted. EKI is explicit that it
+   is the tud-participle's negative counterpart and "jääb alati
+   käändumatuks" — `täitmata lepingute reserv`, not *täitmatute. The old
+   ending test listed only -tud/-dud/-nud, so every `-mata` attribute was
+   reported as declinable.
+
+2. One the reporter's own citation hints at without stating: -tu caritive
+   adjectives DO agree, and their nominative plural also ends in -tud
+   (`õnnetu` → `õnnetud`, `lugematu` → `lugematud`). An ending test cannot
+   separate those from participles, so it froze them too, yielding
+   *`õnnetud laste` where the correct form is `õnnetute laste`.
+
+The fix consults Vabamorf: a frozen attributive is an adjective carrying
+NO case/number form, a declining one carries `sg n` / `pl n`. The ending
+list survives as a fallback, because Vabamorf sometimes misanalyses these
+as nouns (`hajutatud` → S/pl n/`hajutatu`) and the ending is right there.
+
+NOTE ON THE BENCHMARK: `scripts/eval_inflection.py` calls this function,
+but inflection_et contains zero `-mata` phrases and no -tu caritive
+plurals among its 200 noun phrases, so it exercises neither defect. It
+cannot catch a regression here. That is what this file is for.
+
+Run via:
+
+    uv run python tests/test_indeclinable.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import server
+
+failures: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+def mata_forms_are_invariant() -> None:
+    """Issue #42. These are everywhere in the legal/administrative register
+    the editorial tools target."""
+    print("-mata forms are indeclinable")
+    for w in ("täitmata", "kirjutamata", "avaldamata", "allkirjastamata",
+              "esitamata", "tasumata", "kooskõlastamata"):
+        check(f"{w}", server._is_indeclinable_attr(w) is True)
+
+
+def tu_caritives_still_agree() -> None:
+    """The trap an ending test cannot see: -tu plurals also end in -tud."""
+    print("-tu caritive adjectives still decline")
+    for w in ("õnnetu", "lugematu", "kasutu", "abitu"):
+        check(f"{w} (singular)", server._is_indeclinable_attr(w) is False)
+    for w in ("õnnetud", "lugematud", "kasutud", "abitud"):
+        check(f"{w} (nominative plural, ends in -tud)",
+              server._is_indeclinable_attr(w) is False,
+              "an ending test wrongly freezes this")
+
+
+def participles_unchanged() -> None:
+    """The behaviour that was already correct must stay correct."""
+    print("participles remain indeclinable")
+    for w in ("tuntud", "ettenähtud", "läbimõeldud", "rafineeritud",
+              "surnud", "närbunud", "hajutatud"):
+        check(f"{w}", server._is_indeclinable_attr(w) is True)
+    # hajutatud is the documented Vabamorf misanalysis (S/pl n/hajutatu).
+    # It must come out True via the ending fallback, not the adjective path.
+    pos, _form = server._attr_morphology("hajutatud")
+    check("hajutatud is still misanalysed as a noun (fallback is exercised)",
+          pos != "A", f"pos={pos!r} — if this is now 'A', the fallback is untested here")
+
+
+def ordinary_adjectives_and_lexical_indeclinables() -> None:
+    print("everything else is unchanged")
+    for w in ("suur", "ilus", "rahuldav", "kiire", "sinine"):
+        check(f"{w} declines", server._is_indeclinable_attr(w) is False)
+    for w in sorted(server._INDECLINABLE_ADJ_ET)[:5]:
+        check(f"lexical indeclinable {w}", server._is_indeclinable_attr(w) is True)
+
+
+def caller_supplied_morphology() -> None:
+    """analyze_morphology passes the analysis it already has, to avoid a
+    second Vabamorf pass. Both paths must agree."""
+    print("caller-supplied pos/form matches the looked-up answer")
+    for w in ("täitmata", "tuntud", "õnnetud", "suur"):
+        pos, form = server._attr_morphology(w)
+        supplied = server._is_indeclinable_attr(w, pos, form)
+        looked_up = server._is_indeclinable_attr(w)
+        check(f"{w}: supplied == looked up ({supplied})", supplied == looked_up,
+              f"supplied={supplied} looked_up={looked_up}")
+
+    # An adjective carrying a case/number form declines, whatever it ends in.
+    check("A + 'pl n' declines even with a -tud ending",
+          server._is_indeclinable_attr("õnnetud", "A", "pl n") is False)
+    check("A + empty form is frozen",
+          server._is_indeclinable_attr("tuntud", "A", "") is True)
+    # A lexical indeclinable wins regardless of what morphology says.
+    check("lexical list beats a supplied form",
+          server._is_indeclinable_attr("täis", "A", "sg n") is True)
+
+
+def end_to_end_through_the_tool() -> None:
+    print("analyze_morphology reports it correctly")
+    for phrase, expected in (
+        ("täitmata kohustused", {"täitmata": True, "kohustused": False}),
+        ("õnnetud lapsed", {"õnnetud": False, "lapsed": False}),
+        ("tuntud laulja", {"tuntud": True, "laulja": False}),
+    ):
+        got = {t["word"]: t["indeclinable"] for t in server.analyze_morphology(phrase)}
+        check(f"{phrase!r} -> {got}", got == expected, f"expected {expected}")
+
+
+def probe_is_cached_and_safe() -> None:
+    print("_attr_morphology")
+    check("returns a (pos, form) tuple",
+          isinstance(server._attr_morphology("suur"), tuple))
+    check("is cached", hasattr(server._attr_morphology, "cache_clear"))
+    # Junk input must degrade to the ending fallback rather than raise.
+    for junk in ("", "   ", "123", "!!!", "x" * 300):
+        try:
+            server._is_indeclinable_attr(junk)
+            check(f"{junk[:12]!r} handled", True)
+        except Exception as e:
+            check(f"{junk[:12]!r} handled", False, f"{type(e).__name__}: {e}")
+
+
+mata_forms_are_invariant()
+tu_caritives_still_agree()
+participles_unchanged()
+ordinary_adjectives_and_lexical_indeclinables()
+caller_supplied_morphology()
+end_to_end_through_the_tool()
+probe_is_cached_and_safe()
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("\nall indeclinable-attribute tests passed")

--- a/tests/test_indeclinable.py
+++ b/tests/test_indeclinable.py
@@ -77,9 +77,10 @@ def participles_unchanged() -> None:
         check(f"{w}", server._is_indeclinable_attr(w) is True)
     # hajutatud is the documented Vabamorf misanalysis (S/pl n/hajutatu).
     # It must come out True via the ending fallback, not the adjective path.
-    pos, _form = server._attr_morphology("hajutatud")
+    analyses = server._attr_analyses("hajutatud")
     check("hajutatud is still misanalysed as a noun (fallback is exercised)",
-          pos != "A", f"pos={pos!r} — if this is now 'A', the fallback is untested here")
+          not any(p == "A" for p, _f in analyses),
+          f"{analyses} — if an 'A' reading appears, the fallback is untested here")
 
 
 def ordinary_adjectives_and_lexical_indeclinables() -> None:
@@ -90,25 +91,40 @@ def ordinary_adjectives_and_lexical_indeclinables() -> None:
         check(f"lexical indeclinable {w}", server._is_indeclinable_attr(w) is True)
 
 
-def caller_supplied_morphology() -> None:
-    """analyze_morphology passes the analysis it already has, to avoid a
+def caller_supplied_analyses() -> None:
+    """analyze_morphology passes the analyses it already has, to avoid a
     second Vabamorf pass. Both paths must agree."""
-    print("caller-supplied pos/form matches the looked-up answer")
-    for w in ("täitmata", "tuntud", "õnnetud", "suur"):
-        pos, form = server._attr_morphology(w)
-        supplied = server._is_indeclinable_attr(w, pos, form)
+    print("caller-supplied analyses match the looked-up answer")
+    for w in ("täitmata", "tuntud", "õnnetud", "suur", "teemata"):
+        supplied = server._is_indeclinable_attr(w, server._attr_analyses(w))
         looked_up = server._is_indeclinable_attr(w)
         check(f"{w}: supplied == looked up ({supplied})", supplied == looked_up,
               f"supplied={supplied} looked_up={looked_up}")
 
-    # An adjective carrying a case/number form declines, whatever it ends in.
-    check("A + 'pl n' declines even with a -tud ending",
-          server._is_indeclinable_attr("õnnetud", "A", "pl n") is False)
-    check("A + empty form is frozen",
-          server._is_indeclinable_attr("tuntud", "A", "") is True)
+    # Only adjective readings with a case/number form => it declines.
+    check("A/'pl n' alone declines even with a -tud ending",
+          server._is_indeclinable_attr("õnnetud", (("A", "pl n"),)) is False)
+    check("an A/'' reading anywhere freezes it",
+          server._is_indeclinable_attr("tuntud", (("A", "pl n"), ("A", ""))) is True)
+    # Ordering must not decide the verdict — that was the fragility of
+    # taking only Vabamorf's first analysis.
+    check("verdict is order-independent",
+          server._is_indeclinable_attr("tuntud", (("A", ""), ("V", "tud"))) ==
+          server._is_indeclinable_attr("tuntud", (("V", "tud"), ("A", ""))))
     # A lexical indeclinable wins regardless of what morphology says.
-    check("lexical list beats a supplied form",
-          server._is_indeclinable_attr("täis", "A", "sg n") is True)
+    check("lexical list beats supplied analyses",
+          server._is_indeclinable_attr("täis", (("A", "sg n"),)) is True)
+
+
+def abessive_nouns_are_not_frozen() -> None:
+    """A noun whose stem ends in -ma forms its abessive in -mata
+    (teema -> teemata). Adding 'mata' to the ending list froze those; the
+    abessive guard is what stops it."""
+    print("-mata abessive nouns still decline")
+    for w in ("teemata", "kliimata", "draamata", "skeemata", "reklaamata"):
+        check(f"{w} (abessive of a -ma stem)",
+              server._is_indeclinable_attr(w) is False,
+              "the -mata ending must not freeze an inflected noun")
 
 
 def end_to_end_through_the_tool() -> None:
@@ -123,10 +139,18 @@ def end_to_end_through_the_tool() -> None:
 
 
 def probe_is_cached_and_safe() -> None:
-    print("_attr_morphology")
-    check("returns a (pos, form) tuple",
-          isinstance(server._attr_morphology("suur"), tuple))
-    check("is cached", hasattr(server._attr_morphology, "cache_clear"))
+    print("_attr_analyses")
+    check("returns a tuple of (pos, form) pairs",
+          isinstance(server._attr_analyses("suur"), tuple))
+    check("is cached", hasattr(server._attr_analyses, "cache_clear"))
+    # Capitalisation must not change the verdict. The probe is looked up
+    # from the lowercased word, so 'Täitmata' and 'täitmata' agree and
+    # share one cache entry.
+    for w in ("täitmata", "tuntud", "õnnetud", "teemata", "suur"):
+        check(f"{w}: verdict is case-stable",
+              server._is_indeclinable_attr(w)
+              == server._is_indeclinable_attr(w.capitalize())
+              == server._is_indeclinable_attr(w.upper()))
     # Junk input must degrade to the ending fallback rather than raise.
     for junk in ("", "   ", "123", "!!!", "x" * 300):
         try:
@@ -140,7 +164,8 @@ mata_forms_are_invariant()
 tu_caritives_still_agree()
 participles_unchanged()
 ordinary_adjectives_and_lexical_indeclinables()
-caller_supplied_morphology()
+caller_supplied_analyses()
+abessive_nouns_are_not_frozen()
 end_to_end_through_the_tool()
 probe_is_cached_and_safe()
 

--- a/tests/test_indeclinable.py
+++ b/tests/test_indeclinable.py
@@ -95,8 +95,12 @@ def ordinary_adjectives_and_lexical_indeclinables() -> None:
     print("everything else is unchanged")
     for w in ("suur", "ilus", "rahuldav", "kiire", "sinine"):
         check(f"{w} declines", server._is_indeclinable_attr(w) is False)
-    for w in sorted(server._INDECLINABLE_ADJ_ET)[:5]:
-        check(f"lexical indeclinable {w}", server._is_indeclinable_attr(w) is True)
+    # Explicit words, not `sorted(_INDECLINABLE_ADJ_ET)[:5]` — deriving the
+    # cases from the set under test means the assertion cannot fail.
+    for w in ("täis", "eri", "väärt", "alasti", "purjus"):
+        check(f"lexical indeclinable {w}",
+              server._is_indeclinable_attr(w) is True,
+              "expected in _INDECLINABLE_ADJ_ET")
 
 
 def caller_supplied_analyses() -> None:
@@ -182,14 +186,26 @@ def known_limits_are_documented() -> None:
     documented behaviour and the real behaviour in step: if a future change
     fixes them, this test fails and the docstring gets updated with it."""
     print("documented known limits")
-    for w in ("korratud", "maitsetud"):
+    for w in ("töötud", "korratud", "maitsetud"):
         check(f"{w}: caritive whose lemma is indistinguishable from deverbal",
               server._is_indeclinable_attr(w) is True,
               "documented limit — lemma -tu matches both classes")
     for w in ("nõutud", "kaalutud"):
         check(f"{w}: participle/caritive homograph resolves to the participle",
               server._is_indeclinable_attr(w) is True,
-              "documented limit — needs semantics, not morphology")
+              "documented limit, needs semantics not morphology")
+
+    # Context resolves what isolation cannot. This is the honest shape of
+    # the limit: the TOOL gets töötud right, the bare-word fallback does
+    # not, and callers with a sentence should pass their analyses.
+    in_context = {t["word"]: t["indeclinable"]
+                  for t in server.analyze_morphology("töötud inimesed said abi")}
+    check("context resolves töötud correctly where isolation cannot",
+          in_context["töötud"] is False,
+          f"{in_context} — analyze_morphology should decline this caritive")
+    check("...and that is a genuine isolated/contextual divergence",
+          server._is_indeclinable_attr("töötud") is True,
+          "if isolation now agrees, tighten the docstring's KNOWN LIMITS")
 
 
 def end_to_end_through_the_tool() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Fixes #42, reported by @tomkabel with the normative citations.

## The reported bug

The `-mata` form is the tud-participle's negative counterpart, and EKI states it "jääb alati käändumatuks": `täitmata lepingute reserv`, not *täitmatute. The ending test listed only `-tud`/`-dud`/`-nud`, so every `-mata` attribute came back `indeclinable: false`, nudging a consumer toward the non-standard declined form. That bites hardest in the legal and administrative register the editorial tools target.

## Why not the proposed one-liner

The issue proposes adding `"mata"` to the ending tuple. That fixes the reported case, but the same ending test was already wrong in two other directions, and adding `-mata` introduces a third.

**1. Ordinary plural nouns were frozen.** Any Estonian noun whose nominative plural ends `-tud`/`-dud`/`-nud`: `raamatud`, `linnud`, `laenud`, `kohtud`, `toidud`, `säästud`. An agent following the documented contract writes *`paksude raamatud` for `paksude raamatute`. This predates #42 but lives in the same code path.

**2. `-tu` caritives agree, and their plural also ends in `-tud`.** `õnnetu` → `õnnetud`, `lugematu` → `lugematud`. The reporter's own EKI citation points at this. Verified against Vabamorf's synthesis:

```
õnnetu -> pl n = ['õnnetud']      õnnetu -> pl g = ['õnnetute']
```

**3. A noun whose genitive ends `-ma` forms its abessive in `-mata`.** `teema` → `teemata`, `kliima` → `kliimata`. Adding `"mata"` to the ending list freezes those inflected nouns. The reporter predicted this class and was right.

## The fix

Consult Vabamorf instead of guessing from the ending, in this order:

1. An **adjective reading** decides it. An invariant attributive has one with no case/number form; a declining one only ever carries `sg n` / `pl n`.
2. `-mata` is invariant **unless it is a noun abessive**.
3. `-tud`/`-dud`/`-nud` is invariant only when some **lemma looks deverbal**, which separates `hajutatu` from `raamat`.

The ending fallback still matters because Vabamorf misanalyses some participles as nouns (`hajutatud` → `S/pl n/hajutatu`). `analyze_morphology` passes the analyses it already has, so the hot path costs nothing extra.

Two further things the ending test got wrong, both of which turned out to matter:

- **Analysis ordering.** A participle comes back as `A/''`, `V/tud`, `A/pl n`, `A/sg n`. Reading only the first meant `lugupeetud`, the standard salutation in Estonian official correspondence, reported as declinable. All adjective readings are considered now.
- **Capitalisation.** The probe was keyed on the original cased word while the lexical check lowercased, so `Täitmata` (`H/sg n`) took a different branch from `täitmata` (`V/mata`). Now looked up from the lowercased form.

## Known limits, stated rather than papered over

Vabamorf separates *most* `-tu` caritives from participles, not all. Two classes remain frozen and the tests assert them, so the docs and the behaviour can't drift:

- A caritive whose lemma ends `-tu` and which Vabamorf tags only as a noun (`korratud` → `korratu`, `maitsetud`). That lemma is indistinguishable from a deverbal `hajutatu`.
- Participle/caritive homographs (`nõutud`, `kaalutud`, `kohatud`). Separating them needs semantics, not morphology.

## The benchmark

`scripts/eval_inflection.py` calls this function and the README advertises 96.5%. **Unchanged at 96.5% first-candidate / 99.1% any-candidate.**

That is not luck worth trusting, so I checked why: inflection_et's 200 noun phrases contain **zero** `-mata` attributes, and its `-tu` phrases appear only in base singular, so it never sees a caritive plural. It exercises none of these defects and could not have caught them. `tests/test_indeclinable.py` is what guards this now.

## Verification

- 439 checks across 9 suites, `ruff check .` clean
- Premise checked rather than assumed: across 65 ordinary adjectives and a running-text sweep, no adjective tagged `A` with an empty form that isn't a participle, `-mata`, or lexically indeclinable
- 11 assertions in the new test file fail against the old implementation
- Cache confirmed working (152/152 hits, 0.0002 ms); cold cost 0.47 ms, bounded by distinct words
- No new network, filesystem or stdout surface
