### PR TITLE
Hold the nginx proxy on a stable branch, and let the tests say so

### DIFF
--- a/deploy/nginx/Dockerfile
+++ b/deploy/nginx/Dockerfile
@@ -8,9 +8,18 @@
 #
 # Everything else (the config template, the token map, the certificates)
 # is bind-mounted at runtime so it can change without a rebuild.
-# Stable branch, minor pinned so Dependabot can offer the patch bumps.
-# Keep it on a supported branch: out-of-support branches stop getting
-# security fixes and the image starts accumulating CVEs.
+# nginx's STABLE branch. Even minors are stable and odd minors are
+# mainline, and the tags are literally the same images: 1.30-alpine and
+# stable-alpine share a digest, as do 1.31-alpine and mainline-alpine.
+# This container terminates TLS and holds every client's token, so it
+# tracks stable.
+#
+# The tag floats at patch level, so patch fixes arrive on a rebuild with
+# nobody doing anything. What Dependabot can offer here is the next
+# MINOR: take it when it is even (1.32), decline it when it is odd
+# (1.31). Do not sit on an out-of-support branch either, because those
+# stop getting security fixes and the image starts accumulating CVEs.
+# tests/test_deploy.py holds the even-minor half of that rule.
 FROM nginx:1.30-alpine
 
 RUN rm -f /etc/nginx/conf.d/default.conf

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -323,6 +323,16 @@ def compose_is_pinned_and_bounded() -> None:
         froms = re.findall(r"^FROM (\S+)", (ROOT / dockerfile).read_text(), re.M)
         check(f"{dockerfile} pins its base images", bool(froms)
               and all(":" in f and not f.endswith(":latest") for f in froms), str(froms))
+    # nginx ships stable on even minors and mainline on odd ones, and the
+    # tags are the same images: 1.31-alpine IS mainline-alpine. The proxy
+    # holds the TLS key and every client token, so an accepted minor bump
+    # onto an odd branch would be a posture change nobody asked for.
+    nginx_from = re.search(r"^FROM nginx:(\d+)\.(\d+)-alpine",
+                           (ROOT / "deploy/nginx/Dockerfile").read_text(), re.M)
+    check("the proxy names an nginx minor", nginx_from is not None)
+    if nginx_from:
+        check("and it is a stable branch, not mainline", int(nginx_from.group(2)) % 2 == 0,
+              f"1.{nginx_from.group(2)} is odd, so it is mainline")
     check("log files are capped", 'max-size: "10m"' in COMPOSE and 'max-file: "3"' in COMPOSE)
     body = re.search(r"^services:\n(.*?)(?=^\w)", COMPOSE_CODE, re.S | re.M)
     check("a services block exists", body is not None)


### PR DESCRIPTION
Dependabot offered nginx `1.31-alpine` in #46. That tag and `mainline-alpine` are the same image, exactly as `1.30-alpine` and `stable-alpine` are:

```
stable-alpine    sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46
1.30-alpine      sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46
mainline-alpine  sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
1.31-alpine      sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
```

So the bump was a move from stable to mainline, not an update within a branch. The container it applies to terminates TLS and holds every client's token, and the Dockerfile already asked for stable, so #46 was declined. Nothing was wrong with the image itself: it builds, `nginx-module-njs` resolves to 1.31.4.1.0.0, and all 95 checks in `tests/deploy_e2e.sh` pass against it.

Two things made that call harder than it needed to be, and both are fixed here.

The Dockerfile comment said the minor was pinned "so Dependabot can offer the patch bumps". A floating minor tag already picks up patch fixes on a rebuild without anyone acting, so what Dependabot can actually offer at this pin is the next minor. The comment now says which minors are stable, which are mainline, and what to do with each: take 1.32, decline 1.31, and do not sit on a branch after it leaves support.

`tests/test_deploy.py` now holds the even-minor rule, so an odd minor fails the build instead of resting on somebody recognising the number. Verified by pointing the Dockerfile at `1.31-alpine`: the check fails with `1.31 is odd, so it is mainline`.

Comments and one test. No behaviour change.