### PR TITLE
Replace the Smithery badge, which serves a 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Claude is quite bad at Estonian, so this MCP is here to fix that. Give it a shot.
 
 [![CI](https://github.com/silly-geese/estonian-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/silly-geese/estonian-mcp/actions/workflows/ci.yml)
-[![smithery badge](https://smithery.ai/badge/silly-geese/estonian-mcp)](https://smithery.ai/servers/silly-geese/estonian-mcp)
+[![Smithery](https://img.shields.io/badge/Smithery-one--click%20install-000000.svg)](https://smithery.ai/servers/silly-geese/estonian-mcp)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Python 3.10–3.13](https://img.shields.io/badge/python-3.10%E2%80%933.13-blue.svg)](pyproject.toml)
 [![MCP](https://img.shields.io/badge/MCP-stdio%20%2B%20HTTP-7c3aed.svg)](https://modelcontextprotocol.io)


### PR DESCRIPTION
The README's Smithery badge has been rendering as a broken image because the badge endpoint returns an empty 500:

```
https://smithery.ai/badge/silly-geese/estonian-mcp   500, empty body
https://smithery.ai/badge/exa                        500, empty body
https://smithery.ai/servers/silly-geese/estonian-mcp 200
```

It is not this listing. Every server's badge path answers the same way, and Smithery's documentation no longer has a badges page, so the service looks retired rather than briefly down. GitHub proxies README images through camo, which caches the failure and shows the broken-image glyph.

A static shields.io badge takes its place, linking to the same listing and matching the three shields badges already in the README. All five badge URLs now return `image/svg+xml` with a 200.

A dynamic badge was possible: `registry.smithery.ai/servers/silly-geese/estonian-mcp` answers 200 with JSON. It carries no install or usage count though, only fields the README already states in words, so it would add a dependency on an undocumented endpoint and show nothing new.

One line in `README.md`. No code change.