### PR TITLE
Catch a base-image bump that outruns the declared Python support window

### DIFF
--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -362,6 +362,42 @@ def compose_is_pinned_and_bounded() -> None:
               f"stale: {sorted(allowed - placeholders)}")
 
 
+def base_image_matches_declared_support() -> None:
+    print("the app image runs a Python this project claims to support")
+    spec = re.search(r'requires-python\s*=\s*"([^"]+)"', (ROOT / "pyproject.toml").read_text())
+    tag = re.search(r"^FROM python:(\d+)\.(\d+)-slim", (ROOT / "Dockerfile").read_text(), re.M)
+    check("pyproject declares a Python range", spec is not None)
+    check("the Dockerfile names a Python version", tag is not None)
+    if not (spec and tag):
+        return
+
+    image = (int(tag.group(1)), int(tag.group(2)))
+    ops = {
+        ">=": lambda a, b: a >= b,
+        "<=": lambda a, b: a <= b,
+        "==": lambda a, b: a == b,
+        "!=": lambda a, b: a != b,
+        ">": lambda a, b: a > b,
+        "<": lambda a, b: a < b,
+    }
+    unmet = []
+    for clause in spec.group(1).split(","):
+        m = re.match(r"\s*(>=|<=|==|!=|>|<)\s*(\d+)\.(\d+)", clause)
+        check(f"the clause {clause.strip()} is one this test understands", m is not None)
+        if m and not ops[m.group(1)](image, (int(m.group(2)), int(m.group(3)))):
+            unmet.append(clause.strip())
+
+    # Bumping the image alone does not move the support window, and the
+    # failure is silent until runtime: uv honours requires-python, so
+    # inside a python:3.14-slim image with a <3.14 cap it builds /opt/venv
+    # with a DIFFERENT interpreter it downloads, the runtime stage then
+    # runs the image's own python against that venv, and the container
+    # exits before it listens. Widen requires-python first, or leave the
+    # image where it is.
+    check(f"python:{image[0]}.{image[1]}-slim satisfies requires-python",
+          not unmet, f"unmet: {unmet} in {spec.group(1)}")
+
+
 def ignores_keep_secrets_out() -> None:
     print("secrets stay out of git and out of the image")
     gitignore = (ROOT / ".gitignore").read_text()
@@ -602,6 +638,7 @@ upstream_headers_are_ours()
 oauth_metadata_matches_behaviour()
 logged_values_are_sanitised()
 compose_is_pinned_and_bounded()
+base_image_matches_declared_support()
 ignores_keep_secrets_out()
 credential_scripts_work()
 credentials_fail_closed()


### PR DESCRIPTION
Dependabot offered `python:3.14-slim` in #50. The image built and then never served: the `docker` job failed on `curl: (7) Failed to connect to 127.0.0.1 port 8081`, four minutes in, with nothing saying why.

The cause is in the build log:

```
#19 1.955 Using CPython 3.13.1
#19 1.955 Creating virtual environment at: /opt/venv
```

Inside a `python:3.14-slim` image, uv honoured `requires-python = ">=3.10,<3.14"` from `pyproject.toml`, refused the image's own interpreter, and downloaded CPython 3.13.1 to build `/opt/venv`. The runtime stage then runs the image's `python`, which is 3.14, against a virtualenv built for 3.13, so the process exits immediately.

Upstream is not the obstacle. estnltk 1.7.5, scikit-learn 1.9.0 and numpy 2.5.2 all publish cp314 wheels. The obstacle is the support window this project declares, and moving it is a decision about what the package claims to run on, plus the CI matrix and a look at what the hosted service should be running. Not a side effect of an image tag.

So #50 is declined, and this adds the check that makes the next one obvious: `tests/test_deploy.py` compares `FROM python:X.Y-slim` against `requires-python` and names the clause that is unmet. It runs in the `deploy-stack` job, which finishes in about 40 seconds, rather than failing deep inside a four-minute image build.

Verified by pointing the Dockerfile at `3.14-slim`:

```
FAIL python:3.14-slim satisfies requires-python unmet: ['<3.14'] in >=3.10,<3.14
```

One test. No behaviour change.