### PR TITLE
0.5.8: generate the short illative, and stop advertising forms nobody can generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,16 @@ jobs:
           # returns every inflection type, and says the ranking is not
           # corpus-backed rather than implying it is.
           r = server.paradigm("kott")
-          # 28 number-and-case slots. `adt` (the short illative, kotti) is
-          # counted separately: only some words have one.
+          # 28 number-and-case slots. `adt` (the short illative) is counted
+          # separately: only some words have one.
           assert len([f for f in r["forms"] if f["form"] != "adt"]) == 28, r
-          assert [f["surface"] for f in r["forms"] if f["form"] == "adt"] == ["kotti"], r
+          # Asserted on `koti`, not `kott`. Which of kott's two paradigms
+          # leads is decided by corpus ranking, and this job runs BEFORE any
+          # model is installed, so `kott` leads with kota (adt: kotta) here
+          # and with koti once the model is present. An inflected input
+          # picks the table outright, so the expectation holds either way.
+          k = server.paradigm("koti")
+          assert [f["surface"] for f in k["forms"] if f["form"] == "adt"] == ["kotti"], k
           assert r["paradigm_count"] == 2, r
           assert r["ranked_by_corpus_frequency"] is False, r
           assert server.paradigm("esimene")["forms"], "ordinals lost their paradigm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,10 @@ jobs:
           # returns every inflection type, and says the ranking is not
           # corpus-backed rather than implying it is.
           r = server.paradigm("kott")
-          assert len(r["forms"]) == 28, r
+          # 28 number-and-case slots. `adt` (the short illative, kotti) is
+          # counted separately: only some words have one.
+          assert len([f for f in r["forms"] if f["form"] != "adt"]) == 28, r
+          assert [f["surface"] for f in r["forms"] if f["form"] == "adt"] == ["kotti"], r
           assert r["paradigm_count"] == 2, r
           assert r["ranked_by_corpus_frequency"] is False, r
           assert server.paradigm("esimene")["forms"], "ordinals lost their paradigm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.8] — 2026-09-07
+
+Both of these came out of a reader checking our
+`data/inflection_et_eki_disputes.json` against his own Estonian inflection
+corpus and writing to say what he had measured about parallel forms. The
+defects are ours; the prompt to look was his.
+
+### Fixed
+
+- **`paradigm` left out the short illative entirely.** Estonian has two
+  illatives for many words, the long `majasse` and the short `majja`, and
+  Vabamorf generates the short one under a form code of its own (`adt`,
+  no number prefix, singular only). The nominal table never asked for it,
+  so `maja` came back with `majasse` alone, `käsi` with `käesse`, `meri`
+  with `meresse`, `kivi` with `kivisse`. For those words the short form is
+  the one people write, so an agent reading the table would "correct" a
+  correct `majja` into `majasse`, which is the exact failure this server
+  exists to prevent.
+
+  The slot is now generated where it exists and absent where it does not
+  (`raamat`, `auto` and `töö` have no short illative), it carries its
+  Estonian name, and the tool note says both forms are correct so neither
+  gets rewritten into the other.
+
+- **A verb slot that generated nothing.** `tava` sat in the verb form list
+  and synthesises nothing for any verb, so the slot never appeared in a
+  table. Its intended counterpart to the `vat` already there is `tavat`
+  (`kasutatavat`), which does exist and is now generated in its place.
+
+- **The benchmark harness only looked like it scored short illatives.**
+  `scripts/eval_inflection.py` listed `adt` beside `ill`, then prefixed
+  the number and asked Vabamorf for `sg adt`, which answers nothing. So
+  the harness never produced a short form while appearing to support them.
+
+  The published numbers do not move: 99.1% any-candidate and
+  100% EKI-adjudicated, unchanged. 86 of the dataset's 200 singular
+  illative rows carry a short form in their gold, but the gold lists both
+  spellings, so our long-only output scored anyway. That is why a
+  benchmark at 99.1% never revealed a tool that was missing the form
+  Estonians actually use.
+
+### Added
+
+- **A test that a form code nobody can generate cannot sit in a table.**
+  Every code in the nominal and verb lists, and every code the benchmark
+  harness builds, has to synthesise for at least one probe word. That is
+  what turned up `tava`, and it fails on the old `sg adt` spelling.
+
+
 ## [0.5.7] — 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,21 @@ defects are ours; the prompt to look was his.
 
   The slot is now generated where it exists and absent where it does not
   (`raamat`, `auto` and `töö` have no short illative), it carries its
-  Estonian name, and the tool note says both forms are correct so neither
-  gets rewritten into the other.
+  Estonian name, and the tool note says both forms are correct illatives
+  so neither gets "corrected" into the other. The note also says what the
+  table cannot: for most words that have a short illative it is spelled
+  exactly like the singular partitive (`vend`: `venda` is both), so
+  finding a surface in the table does not confirm the case is right where
+  it was used.
 
-- **A verb slot that generated nothing.** `tava` sat in the verb form list
-  and synthesises nothing for any verb, so the slot never appeared in a
-  table. Its intended counterpart to the `vat` already there is `tavat`
-  (`kasutatavat`), which does exist and is now generated in its place.
+- **A verb slot that generated nothing, and one listed twice.** `tava` sat
+  in the verb form list and synthesises nothing for any verb, so its slot
+  never appeared in a table. Its counterpart to the `vat` already there is
+  `tavat` (`kasutatavat`), which does exist and takes its place. `ksid`
+  was listed twice, once for the conditional 2nd person singular and once
+  for the 3rd person plural, which share both surface and label, so the
+  table carried two byte-identical entries; the past tense's identical
+  syncretism (`sid`) was already listed once and this now matches.
 
 - **The benchmark harness only looked like it scored short illatives.**
   `scripts/eval_inflection.py` listed `adt` beside `ill`, then prefixed
@@ -42,11 +50,12 @@ defects are ours; the prompt to look was his.
   the harness never produced a short form while appearing to support them.
 
   The published numbers do not move: 99.1% any-candidate and
-  100% EKI-adjudicated, unchanged. 86 of the dataset's 200 singular
-  illative rows carry a short form in their gold, but the gold lists both
-  spellings, so our long-only output scored anyway. That is why a
-  benchmark at 99.1% never revealed a tool that was missing the form
-  Estonians actually use.
+  100% EKI-adjudicated, unchanged, from two full runs against the pinned
+  dataset revision. 115 of the dataset's 200 singular illative rows carry
+  a short form in their gold that our engine generates, but the gold
+  lists both spellings, so our long-only output scored anyway. That is
+  why a benchmark at 99.1% never revealed a tool that was missing the
+  form Estonians actually use.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ of images is not one, however natural it sounds in ML jargon).
 | --- | --- |
 | `tokenize(text)` | Split text into sentences and words |
 | `analyze_morphology(text)` | Lemma, POS, form, root, ending, clitic, compound parts, ambiguity count, and usage flags (archaic / foreign / interjection / abbreviation / proper-noun) per word |
-| `paradigm(word)` | Full Vabamorf-generated inflection paradigm, 14 cases × 2 numbers for nominals (including ordinals, comparatives and superlatives), ~30 verb forms, with Estonian labels per form. A lemma with several inflection types (`kott` → `koti` or `kota`, two different words) returns one consistent table per type, corpus-ranked, rather than a merged one; pass an inflected form (`koti`) to select the type you mean |
+| `paradigm(word)` | Full Vabamorf-generated inflection paradigm, 14 cases × 2 numbers for nominals (including ordinals, comparatives and superlatives), plus the short illative where a word has one (`majja` beside `majasse`), ~31 verb forms, with Estonian labels per form. A lemma with several inflection types (`kott` → `koti` or `kota`, two different words) returns one consistent table per type, corpus-ranked, rather than a merged one; pass an inflected form (`koti`) to select the type you mean |
 | `lemmatize(text)` | Just the dictionary form per word |
 | `pos_tag(text)` | Just the part-of-speech tag per word |
 | `spell_check(text)` | Spelling check + correction suggestions |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.7"
+version = "0.5.8"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/scripts/eval_inflection.py
+++ b/scripts/eval_inflection.py
@@ -82,7 +82,7 @@ _CASE = {
     "nimetav": ["n"],      # nominative
     "omastav": ["g"],      # genitive
     "osastav": ["p"],      # partitive
-    "sisseütlev": ["ill"], # illative, long form; the short one is below
+    "sisseütlev": ["ill"], # illative, long form only; short one below
 }
 
 # The SHORT ILLATIVE (aditiiv) is spelled without a number prefix and
@@ -102,11 +102,18 @@ def forms_for(case: str, num: str) -> list[str]:
     call the same construction the scoring does. Checking the constant
     alone would not have caught the original defect: the constant was
     right and the string built from it ("sg adt") was not.
+
+    ORDER MATTERS. word_surfaces() takes form_codes[0] as the first
+    candidate, and first-candidate accuracy is a published number, so the
+    long illative has to stay in front: putting the short one first drops
+    it from 99.1% to 87.9%.
     """
     codes = [f"{num} {c}" for c in _CASE[case]]
     if case == "sisseütlev" and num == "sg":
         codes.append(_SHORT_ILLATIVE_FORM)
     return codes
+
+
 _KEY_FORM = "sg g"   # the form Estonian reads the inflection type off
 
 

--- a/scripts/eval_inflection.py
+++ b/scripts/eval_inflection.py
@@ -63,8 +63,6 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from datasets import load_dataset
-
 _ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_ROOT))
 from server import (
@@ -84,8 +82,17 @@ _CASE = {
     "nimetav": ["n"],      # nominative
     "omastav": ["g"],      # genitive
     "osastav": ["p"],      # partitive
-    "sisseütlev": ["ill", "adt"],  # illative (long + short)
+    "sisseütlev": ["ill"], # illative, long form; the short one is below
 }
+
+# The SHORT ILLATIVE (aditiiv) is spelled without a number prefix and
+# exists only in the singular. It used to sit in _CASE as "adt", which
+# the loop below turned into "sg adt" — a form string Vabamorf answers
+# nothing to, so the branch generated no short illatives at all while
+# looking like it did. 86 of the dataset's 200 singular illative rows
+# carry a short form in their gold; they scored anyway, because the gold
+# lists both spellings, which is why the benchmark never showed this.
+_SHORT_ILLATIVE_FORM = "adt"
 _KEY_FORM = "sg g"   # the form Estonian reads the inflection type off
 
 
@@ -156,6 +163,8 @@ def main() -> None:
         print(render_disputes(doc))
         return
 
+    from datasets import load_dataset
+
     ds = load_dataset("TalTechNLP/inflection_et", split="train")
 
     # Disputes, keyed for lookup. A dispute is honoured only if the gold
@@ -180,6 +189,8 @@ def main() -> None:
         gold = set(row["inflection"])
         num = _NUM[row["plurality"]]
         forms = [f"{num} {c}" for c in _CASE[row["case"]]]
+        if row["case"] == "sisseütlev" and num == "sg":
+            forms.append(_SHORT_ILLATIVE_FORM)
         words = phrase.split()
         key = (row["plurality"], row["case"])
         n += 1

--- a/scripts/eval_inflection.py
+++ b/scripts/eval_inflection.py
@@ -93,6 +93,20 @@ _CASE = {
 # carry a short form in their gold; they scored anyway, because the gold
 # lists both spellings, which is why the benchmark never showed this.
 _SHORT_ILLATIVE_FORM = "adt"
+
+
+def forms_for(case: str, num: str) -> list[str]:
+    """The Vabamorf form codes to synthesize for one dataset row.
+
+    A function rather than an expression inline in the loop, so a test can
+    call the same construction the scoring does. Checking the constant
+    alone would not have caught the original defect: the constant was
+    right and the string built from it ("sg adt") was not.
+    """
+    codes = [f"{num} {c}" for c in _CASE[case]]
+    if case == "sisseütlev" and num == "sg":
+        codes.append(_SHORT_ILLATIVE_FORM)
+    return codes
 _KEY_FORM = "sg g"   # the form Estonian reads the inflection type off
 
 
@@ -188,9 +202,7 @@ def main() -> None:
         phrase = row["noun_phrase"]
         gold = set(row["inflection"])
         num = _NUM[row["plurality"]]
-        forms = [f"{num} {c}" for c in _CASE[row["case"]]]
-        if row["case"] == "sisseütlev" and num == "sg":
-            forms.append(_SHORT_ILLATIVE_FORM)
+        forms = forms_for(row["case"], num)
         words = phrase.split()
         key = (row["plurality"], row["case"])
         n += 1

--- a/server.py
+++ b/server.py
@@ -578,7 +578,10 @@ _VERB_FORMS: tuple[str, ...] = (
     # past indicative
     "sin", "sid", "s", "sime", "site",
     # conditional
-    "ksin", "ksid", "ks", "ksime", "ksite", "ksid",
+    # `ksid` covers the 2nd person singular and the 3rd person plural,
+    # one surface with one label, so it is listed once. `sid` in the past
+    # tense above is the same syncretism and is listed once too.
+    "ksin", "ksid", "ks", "ksime", "ksite",
     # participles
     "nud", "tud", "v", "tav",
     # imperative (mostly 2nd / 3rd person)
@@ -1791,8 +1794,12 @@ def _paradigm(word: str) -> dict:
             "better than the bare lemma when a word has several paradigms: "
             "it tells the server which one you mean. Where a word has both "
             "'ainsuse sisseütlev' (majasse) and 'ainsuse lühike sisseütlev' "
-            "(majja), BOTH are correct and the short one is usually the "
-            "commoner: do not rewrite one into the other."
+            "(majja), both are correct illatives and the short one is often "
+            "the commoner, so neither should be 'corrected' into the other. "
+            "Note that for most words with a short illative the surface is "
+            "identical to the singular partitive (vend: venda is both), so "
+            "finding a word in this table does NOT confirm the case is "
+            "right for the sentence it appears in."
         ),
     }
     if key:
@@ -1845,11 +1852,15 @@ def paradigm(word: Annotated[str, Field(description="A single Estonian word (lem
     comparatives, superlatives): produces all 14 cases × 2 numbers = up to
     28 forms, plus the SHORT ILLATIVE (`adt`, ainsuse lühike sisseütlev)
     for the words that have one: `majja` beside `majasse`, `kätte` beside
-    `käesse`. Both are correct where both appear, and the short one is
-    usually the commoner, so do not rewrite either into the other. For
-    verbs: produces infinitives, present/past/conditional indicative,
-    imperative, and participles (~31 forms). Other parts of speech
-    (adverbs, conjunctions, particles) don't inflect, so `forms` is empty.
+    `käesse`. Both are correct illatives and the short one is often the
+    commoner, so neither should be "corrected" into the other. For most
+    words that have one, though, the short illative is spelled exactly
+    like the singular partitive (`vend`: `venda` is both), so a surface
+    appearing in this table does not confirm the case is right where it
+    was used. For verbs: produces infinitives, present/past/conditional
+    indicative, imperative, and participles (~30 forms). Other parts of
+    speech (adverbs, conjunctions, particles) don't inflect, so `forms`
+    is empty.
 
     Each form entry has the Vabamorf form code (e.g. `sg p`, `ksin`),
     its Estonian label (e.g. `ainsuse osastav`, `tingiv 1.p ainsus`),

--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 _TRUSTED_PROXY_HOPS = max(0, int(os.environ.get("ESTNLTK_MCP_TRUSTED_PROXY_HOPS", "1")))
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.7"
+SERVER_VERSION = "0.5.8"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -534,8 +534,18 @@ _POS_USAGE_NOTES_ET: dict[str, tuple[str, str]] = {
 # Vabamorf.synthesize(lemma, form, pos). Phase-1 scope: the most
 # commonly-needed forms per word class, not every possible form.
 
+# `adt` is the SHORT ILLATIVE (lühike sisseütlev, aditiiv): majja beside
+# majasse, kätte beside käesse, merre beside meresse. It is a Vabamorf
+# form of its own, spelled without a number prefix ("adt", never
+# "sg adt", which synthesises nothing), and it exists only in the
+# singular. Words that have no short illative return nothing for it and
+# the slot is simply absent, which is what every empty form does here.
+#
+# Leaving it out was not a missing nicety. For maja, tuba, käsi, meri and
+# kivi the short form is the one Estonians write, so a table containing
+# only majasse invites a caller to "correct" a correct majja.
 _NOMINAL_FORMS: tuple[str, ...] = (
-    "sg n", "sg g", "sg p", "sg ill", "sg in", "sg el", "sg all",
+    "sg n", "sg g", "sg p", "sg ill", "adt", "sg in", "sg el", "sg all",
     "sg ad", "sg abl", "sg tr", "sg ter", "sg es", "sg ab", "sg kom",
     "pl n", "pl g", "pl p", "pl ill", "pl in", "pl el", "pl all",
     "pl ad", "pl abl", "pl tr", "pl ter", "pl es", "pl ab", "pl kom",
@@ -545,6 +555,7 @@ _NOMINAL_FORMS: tuple[str, ...] = (
 _CASE_LABELS_ET: dict[str, str] = {
     "sg n": "ainsuse nimetav", "sg g": "ainsuse omastav",
     "sg p": "ainsuse osastav", "sg ill": "ainsuse sisseütlev",
+    "adt": "ainsuse lühike sisseütlev",
     "sg in": "ainsuse seesütlev", "sg el": "ainsuse seestütlev",
     "sg all": "ainsuse alaleütlev", "sg ad": "ainsuse alalütlev",
     "sg abl": "ainsuse alaltütlev", "sg tr": "ainsuse saav",
@@ -561,7 +572,7 @@ _CASE_LABELS_ET: dict[str, str] = {
 
 _VERB_FORMS: tuple[str, ...] = (
     # infinitives + supine
-    "ma", "da", "vat", "mas", "mast", "mata",
+    "ma", "da", "vat", "tavat", "mas", "mast", "mata",
     # present indicative (1sg, 2sg, 3sg, 1pl, 2pl, 3pl)
     "n", "d", "b", "me", "te", "vad",
     # past indicative
@@ -569,7 +580,7 @@ _VERB_FORMS: tuple[str, ...] = (
     # conditional
     "ksin", "ksid", "ks", "ksime", "ksite", "ksid",
     # participles
-    "nud", "tud", "v", "tav", "tava",
+    "nud", "tud", "v", "tav",
     # imperative (mostly 2nd / 3rd person)
     "gu", "gem", "ge",
 )
@@ -649,7 +660,7 @@ _REPETITION_SKIP_POS: frozenset[str] = frozenset({
 
 _VERB_LABELS_ET: dict[str, str] = {
     "ma": "ma-tegevusnimi", "da": "da-tegevusnimi",
-    "vat": "vat-vorm", "mas": "mas-vorm",
+    "vat": "vat-vorm", "tavat": "tavat-vorm", "mas": "mas-vorm",
     "mast": "mast-vorm", "mata": "mata-vorm",
     "n": "olevik 1.p ainsus", "d": "olevik 2.p ainsus",
     "b": "olevik 3.p ainsus", "me": "olevik 1.p mitmus",
@@ -662,7 +673,6 @@ _VERB_LABELS_ET: dict[str, str] = {
     "ksite": "tingiv 2.p mitmus",
     "nud": "mineviku kesksõna", "tud": "tegumoeline kesksõna",
     "v": "olevikuline kesksõna", "tav": "tegumoeline olevikuline kesksõna",
-    "tava": "umbisikuline olevikuline kesksõna",
     "gu": "käskiv 3.p ainsus", "gem": "käskiv 1.p mitmus",
     "ge": "käskiv 2.p mitmus",
 }
@@ -1779,7 +1789,10 @@ def _paradigm(word: str) -> dict:
             "morphologically possible, not what a native speaker would "
             "necessarily use. Passing an INFLECTED form (e.g. 'koti') is "
             "better than the bare lemma when a word has several paradigms: "
-            "it tells the server which one you mean."
+            "it tells the server which one you mean. Where a word has both "
+            "'ainsuse sisseütlev' (majasse) and 'ainsuse lühike sisseütlev' "
+            "(majja), BOTH are correct and the short one is usually the "
+            "commoner: do not rewrite one into the other."
         ),
     }
     if key:
@@ -1830,10 +1843,13 @@ def paradigm(word: Annotated[str, Field(description="A single Estonian word (lem
 
     For nominals (nouns, adjectives, pronouns, cardinals, ordinals,
     comparatives, superlatives): produces all 14 cases × 2 numbers = up to
-    28 forms. For verbs: produces infinitives, present/past/conditional
-    indicative, imperative, and participles (~30 forms). Other parts of
-    speech (adverbs, conjunctions, particles) don't inflect, so `forms` is
-    empty.
+    28 forms, plus the SHORT ILLATIVE (`adt`, ainsuse lühike sisseütlev)
+    for the words that have one: `majja` beside `majasse`, `kätte` beside
+    `käesse`. Both are correct where both appear, and the short one is
+    usually the commoner, so do not rewrite either into the other. For
+    verbs: produces infinitives, present/past/conditional indicative,
+    imperative, and participles (~31 forms). Other parts of speech
+    (adverbs, conjunctions, particles) don't inflect, so `forms` is empty.
 
     Each form entry has the Vabamorf form code (e.g. `sg p`, `ksin`),
     its Estonian label (e.g. `ainsuse osastav`, `tingiv 1.p ainsus`),
@@ -3168,7 +3184,7 @@ def _check_object_case(text: str) -> dict:
             # Skip if already partitive (correct) or clearly non-object case.
             if form in _NON_OBJECT_CASES:
                 continue
-            if " p" in form:   # partitive ('sg p', 'pl p', 'adt')
+            if " p" in form:   # partitive ('sg p', 'pl p')
                 continue
             if form not in _DIRECT_OBJECT_CASES:
                 continue

--- a/skills/estonian-writing-assistant/SKILL.md
+++ b/skills/estonian-writing-assistant/SKILL.md
@@ -26,7 +26,7 @@ The hard rule, applied throughout this skill:
 | `spell_check` | First pass on any Estonian text the user wrote. Cheapest validation. |
 | `lemmatize` | Get dictionary forms — for vocabulary study, deduping word stems, citation. |
 | `analyze_morphology` | Full analysis with case form, root, ending, compound parts, ambiguity count, and a usage flag (`archaic` / `foreign` / `interjection` / `abbreviation` / `proper-noun`). The authoritative tool when discussing grammar. |
-| `paradigm` | Generates the full inflection paradigm for a word — all 14 cases for nouns, ~30 forms for verbs. Use when the user asks "what's the X-case of Y" or wants to see every form. Don't try to recall paradigms from memory. |
+| `paradigm` | Generates the full inflection paradigm for a word — all 14 cases for nouns plus the short illative where a word has one (majja beside majasse), ~30 forms for verbs. Use when the user asks "what's the X-case of Y" or wants to see every form. Don't try to recall paradigms from memory. |
 | `pos_tag` | When you only need POS, e.g., filtering a list to nouns. |
 | `tokenize` | Sentence + word boundaries. Useful before per-sentence operations. |
 | `synonyms` | Same-meaning alternatives via Estonian WordNet. Returns synsets grouped by sense. |

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -304,9 +304,10 @@ def synthesis_invariants() -> None:
           isinstance(server._synthesize("qwertyxyz", "sg g", "S"), list))
 
     print("no form is silently dropped from a table")
-    # 31 for the verb since `tava`, which synthesised nothing for any
-    # verb, was replaced by `tavat`, which does (kasutatavat).
-    cases = [("kott", 28), ("maitse", 28), ("esimene", 28), ("kasutama", 31)]
+    # 30 for the verb: `tava` synthesised nothing for any verb and was
+    # replaced by `tavat`, which does (kasutatavat), and the duplicated
+    # `ksid` slot is now listed once like the `sid` it mirrors.
+    cases = [("kott", 28), ("maitse", 28), ("esimene", 28), ("kasutama", 30)]
     if HAVE_CORPUS:
         cases.append(("kaunis", 28))   # reaches 28 only once promoted
     for word, n in cases:
@@ -606,14 +607,6 @@ def disputes_file_is_well_formed() -> None:
     check("sources are cited", len(DISPUTES.get("sources", [])) >= 1)
 
 
-ordinals_comparatives_superlatives_inflect()
-no_form_is_invented_for_a_word_that_lacks_it()
-verb_free_variants_are_not_two_inflection_types()
-a_shared_form_does_not_select_a_type()
-a_rare_reading_is_not_promoted()
-unambiguous_words_never_touch_the_model()
-every_return_path_carries_paradigm_count()
-
 def the_short_illative_is_in_the_table() -> None:
     """`adt`, the lühike sisseütlev: majja beside majasse.
 
@@ -647,9 +640,19 @@ def the_short_illative_is_in_the_table() -> None:
     r = server._paradigm("maja")
     labels = [e["form_estonian"] for e in r["forms"] if e["form"] == "adt"]
     check("adt is labelled in Estonian", labels == ["ainsuse lühike sisseütlev"], str(labels))
-    check("the note tells a caller not to rewrite one into the other",
-          "lühike sisseütlev" in r["note"] and "do not rewrite" in r["note"],
-          r["note"][-160:])
+    check("the note names the slot and warns against 'correcting' it",
+          "lühike sisseütlev" in r["note"] and "corrected" in r["note"],
+          r["note"][-200:])
+    # For most words that have one, the short illative is spelled exactly
+    # like the singular partitive (vend: venda is both), so a note that
+    # only said "both are correct" would tell an agent to leave a real
+    # case error alone.
+    check("and says the surface does not confirm the case",
+          "singular partitive" in r["note"] and "does NOT confirm" in r["note"],
+          r["note"][-200:])
+    homographs = [w for w in ("vend", "sõber", "president", "kool")
+                  if form_of(server._paradigm(w), "adt") == form_of(server._paradigm(w), "sg p")]
+    check("the homograph the warning is about is real", len(homographs) >= 3, str(homographs))
 
 
 def every_form_string_is_one_vabamorf_accepts() -> None:
@@ -693,6 +696,19 @@ def every_form_string_is_one_vabamorf_accepts() -> None:
                 check(f"harness form {form!r} ({case}) synthesizes", got,
                       "the harness asks Vabamorf for a code it answers nothing to")
 
+    print("and the order the harness builds is the order it scores on")
+    # word_surfaces() takes form_codes[0] as the first candidate, so the
+    # long illative has to come first. Reversing this leaves every other
+    # check green and drops published first-candidate accuracy to 87.9%.
+    check("the long illative is the first candidate",
+          eval_inflection.forms_for("sisseütlev", "sg") == ["sg ill", "adt"],
+          str(eval_inflection.forms_for("sisseütlev", "sg")))
+    for case in eval_inflection._CASE:
+        for num in ("sg", "pl"):
+            built = eval_inflection.forms_for(case, num)
+            check(f"{num} {case} leads with the numbered code",
+                  built[0] == f"{num} {eval_inflection._CASE[case][0]}", str(built))
+
     print("and the short illative reaches the words that have one")
     sg_ill = eval_inflection.forms_for("sisseütlev", "sg")
     produced = {surface for f in sg_ill for surface in server._synthesize("maja", f, "S")}
@@ -705,6 +721,16 @@ def every_form_string_is_one_vabamorf_accepts() -> None:
     check("no other case asks for one either",
           all(eval_inflection._SHORT_ILLATIVE_FORM not in eval_inflection.forms_for(c, "sg")
               for c in eval_inflection._CASE if c != "sisseütlev"))
+
+
+ordinals_comparatives_superlatives_inflect()
+no_form_is_invented_for_a_word_that_lacks_it()
+verb_free_variants_are_not_two_inflection_types()
+a_shared_form_does_not_select_a_type()
+a_rare_reading_is_not_promoted()
+unambiguous_words_never_touch_the_model()
+every_return_path_carries_paradigm_count()
+
 
 estonian_labels_accompany_every_pos_code()
 genuinely_uninflecting_words_still_say_so()

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -681,20 +681,30 @@ def every_form_string_is_one_vabamorf_accepts() -> None:
     except Exception as e:   # pragma: no cover - the harness is dev-only
         check("the eval harness imports without its dataset dependency", False, str(e))
         return
-    check("the harness imports with no `datasets` installed", True)
-    for case, codes in eval_inflection._CASE.items():
+    # Through forms_for(), the function the scoring loop itself calls.
+    # Checking the constant beside it would not have caught the original
+    # defect: the constant was right and the string built from it was not.
+    for case in eval_inflection._CASE:
         for num in ("sg", "pl"):
-            for code in codes:
-                form = f"{num} {code}"
+            built = eval_inflection.forms_for(case, num)
+            check(f"harness builds codes for {num} {case}", bool(built))
+            for form in built:
                 got = any(server._synthesize(w, form, "S") for w in probes_nominal)
-                check(f"harness form {form!r} ({case}) synthesizes", got)
-    short = eval_inflection._SHORT_ILLATIVE_FORM
-    check(f"the harness short illative {short!r} synthesizes",
-          server._synthesize("maja", short, "S") == ["majja"],
-          str(server._synthesize("maja", short, "S")))
-    check("and it is NOT the number-prefixed spelling that generates nothing",
-          server._synthesize("maja", f"sg {short}", "S") == [],
-          "sg adt used to be what the harness asked for")
+                check(f"harness form {form!r} ({case}) synthesizes", got,
+                      "the harness asks Vabamorf for a code it answers nothing to")
+
+    print("and the short illative reaches the words that have one")
+    sg_ill = eval_inflection.forms_for("sisseütlev", "sg")
+    produced = {surface for f in sg_ill for surface in server._synthesize("maja", f, "S")}
+    check("a singular illative row generates majja as well as majasse",
+          produced == {"majja", "majasse"}, str(produced))
+    check("a plural illative row does not ask for a short form",
+          all(f != eval_inflection._SHORT_ILLATIVE_FORM
+              for f in eval_inflection.forms_for("sisseütlev", "pl")),
+          str(eval_inflection.forms_for("sisseütlev", "pl")))
+    check("no other case asks for one either",
+          all(eval_inflection._SHORT_ILLATIVE_FORM not in eval_inflection.forms_for(c, "sg")
+              for c in eval_inflection._CASE if c != "sisseütlev"))
 
 estonian_labels_accompany_every_pos_code()
 genuinely_uninflecting_words_still_say_so()

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -56,6 +56,17 @@ def check(label: str, cond: bool, detail: str = "") -> None:
         print(f"  FAIL {label} {detail}")
 
 
+def case_forms(result: dict) -> list[dict]:
+    """The 28 number-and-case slots, without the short illative.
+
+    `adt` (lühike sisseütlev) exists only for the words that have one:
+    maja gives majja, raamat gives nothing. Counting it would make the
+    expected total depend on the word, so the assertions below count the
+    fixed 28 and the short illative is checked on its own.
+    """
+    return [e for e in result.get("forms", []) if e.get("form") != "adt"]
+
+
 def surfaces(entry: dict) -> list[str]:
     s = entry["surface"]
     return [s] if isinstance(s, str) else list(s)
@@ -96,8 +107,8 @@ def ordinals_comparatives_superlatives_inflect() -> None:
         ("suurim", "U", "suurima", "suurimat"),
     ):
         r = server._paradigm(word)
-        check(f"{word} ({pos}) has 28 forms", len(r.get("forms", [])) == 28,
-              f"got {len(r.get('forms', []))}: {r.get('summary_estonian')}")
+        check(f"{word} ({pos}) has 28 case forms", len(case_forms(r)) == 28,
+              f"got {len(case_forms(r))}: {r.get('summary_estonian')}")
         check(f"{word} sg g = {gen}", gen in form_of(r, "sg g"), str(form_of(r, "sg g")))
         check(f"{word} sg p = {part}", part in form_of(r, "sg p"), str(form_of(r, "sg p")))
         check(f"{word} POS reported as {pos}", r.get("partofspeech") == pos,
@@ -126,7 +137,7 @@ def inflecting_reading_is_found() -> None:
         skipped.append("inflecting_reading_is_found")
         return
     r = server._paradigm("kaunis")
-    check("kaunis has a paradigm", len(r.get("forms", [])) == 28,
+    check("kaunis has a paradigm", len(case_forms(r)) == 28,
           f"{r.get('summary_estonian')}")
     check("kaunis sg g = kauni", "kauni" in form_of(r, "sg g"), str(form_of(r, "sg g")))
     check("kaunis sg p = kaunist", "kaunist" in form_of(r, "sg p"),
@@ -293,13 +304,16 @@ def synthesis_invariants() -> None:
           isinstance(server._synthesize("qwertyxyz", "sg g", "S"), list))
 
     print("no form is silently dropped from a table")
-    cases = [("kott", 28), ("maitse", 28), ("esimene", 28), ("kasutama", 30)]
+    # 31 for the verb since `tava`, which synthesised nothing for any
+    # verb, was replaced by `tavat`, which does (kasutatavat).
+    cases = [("kott", 28), ("maitse", 28), ("esimene", 28), ("kasutama", 31)]
     if HAVE_CORPUS:
         cases.append(("kaunis", 28))   # reaches 28 only once promoted
     for word, n in cases:
         r = server._paradigm(word)
-        check(f"{word} has {n} forms", len(r.get("forms", [])) == n,
-              f"got {len(r.get('forms', []))}")
+        # Verbs have no short illative, so case_forms() is a no-op there.
+        check(f"{word} has {n} forms", len(case_forms(r)) == n,
+              f"got {len(case_forms(r))}")
 
     print("_paradigm_hints")
     check("an unambiguous lemma needs no hint",
@@ -403,7 +417,7 @@ def a_rare_reading_is_not_promoted() -> None:
         ranks = server._corpus_ranks()
         check("the premise: kauni is attested, koheda is not",
               "kauni" in ranks and "koheda" not in ranks)
-        check("kaunis IS promoted", len(server._paradigm("kaunis")["forms"]) == 28)
+        check("kaunis IS promoted", len(case_forms(server._paradigm("kaunis"))) == 28)
 
     original = server._corpus_ranks
     server._corpus_ranks = lambda: None
@@ -599,6 +613,89 @@ a_shared_form_does_not_select_a_type()
 a_rare_reading_is_not_promoted()
 unambiguous_words_never_touch_the_model()
 every_return_path_carries_paradigm_count()
+
+def the_short_illative_is_in_the_table() -> None:
+    """`adt`, the lühike sisseütlev: majja beside majasse.
+
+    The table used to stop at the long form. For these words the short one
+    is what Estonians write, so a caller reading the table would "correct"
+    a correct majja into majasse — the exact failure this server exists to
+    prevent, and reported by a reader who had measured how much parallel
+    forms cost single-reference scoring.
+    """
+    print("the short illative (aditiiv) is generated")
+    expected = {
+        "maja": "majja", "tuba": "tuppa", "käsi": "kätte", "meri": "merre",
+        "kivi": "kivvi", "jõgi": "jõkke", "vesi": "vette", "suur": "suurde",
+    }
+    for word, short in expected.items():
+        r = server._paradigm(word)
+        got = form_of(r, "adt")
+        check(f"{word} -> {short}", short in got, f"got {got}")
+        # The long form has to survive alongside it, not be replaced.
+        check(f"{word} keeps its long illative", bool(form_of(r, "sg ill")),
+              str(form_of(r, "sg ill")))
+
+    print("and is absent, not empty, where the word has none")
+    for word in ("raamat", "auto", "arvuti", "töö"):
+        r = server._paradigm(word)
+        forms = [e["form"] for e in r.get("forms", [])]
+        check(f"{word} has no adt slot", "adt" not in forms, str(form_of(r, "adt")))
+        check(f"{word} still has its long illative", bool(form_of(r, "sg ill")))
+
+    print("the slot carries its Estonian name")
+    r = server._paradigm("maja")
+    labels = [e["form_estonian"] for e in r["forms"] if e["form"] == "adt"]
+    check("adt is labelled in Estonian", labels == ["ainsuse lühike sisseütlev"], str(labels))
+    check("the note tells a caller not to rewrite one into the other",
+          "lühike sisseütlev" in r["note"] and "do not rewrite" in r["note"],
+          r["note"][-160:])
+
+
+def every_form_string_is_one_vabamorf_accepts() -> None:
+    """A form string the synthesizer does not recognise generates nothing,
+    silently, for every word.
+
+    That is how the short illative went missing twice: absent from the
+    nominal table here, and present but misspelled as "sg adt" in
+    scripts/eval_inflection.py, where it produced no forms at all while
+    looking like support. A form nobody can generate should fail a test,
+    not sit in a tuple.
+    """
+    print("every form string in the paradigm tables can actually be synthesized")
+    probes_nominal = ("maja", "kott", "vesi", "suur", "raamat", "kaunis", "esimene")
+    for form in server._NOMINAL_FORMS:
+        got = any(server._synthesize(w, form, "S") or server._synthesize(w, form, "A")
+                  for w in probes_nominal)
+        check(f"nominal form {form!r} synthesizes", got,
+              "no probe word produced this form; is the tag spelled the way Vabamorf spells it?")
+    probes_verb = ("kasutama", "olema", "tegema")
+    for form in server._VERB_FORMS:
+        got = any(server._synthesize(w, form, "V") for w in probes_verb)
+        check(f"verb form {form!r} synthesizes", got, "no probe verb produced this form")
+
+    print("and so can the ones the benchmark harness builds")
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    try:
+        import eval_inflection
+    except Exception as e:   # pragma: no cover - the harness is dev-only
+        check("the eval harness imports without its dataset dependency", False, str(e))
+        return
+    check("the harness imports with no `datasets` installed", True)
+    for case, codes in eval_inflection._CASE.items():
+        for num in ("sg", "pl"):
+            for code in codes:
+                form = f"{num} {code}"
+                got = any(server._synthesize(w, form, "S") for w in probes_nominal)
+                check(f"harness form {form!r} ({case}) synthesizes", got)
+    short = eval_inflection._SHORT_ILLATIVE_FORM
+    check(f"the harness short illative {short!r} synthesizes",
+          server._synthesize("maja", short, "S") == ["majja"],
+          str(server._synthesize("maja", short, "S")))
+    check("and it is NOT the number-prefixed spelling that generates nothing",
+          server._synthesize("maja", f"sg {short}", "S") == [],
+          "sg adt used to be what the harness asked for")
+
 estonian_labels_accompany_every_pos_code()
 genuinely_uninflecting_words_still_say_so()
 inflecting_reading_is_found()
@@ -613,6 +710,8 @@ junk_input_is_safe()
 eki_rules_hold_on_the_disputed_rows()
 the_two_eki_rules_are_encoded()
 disputes_file_is_well_formed()
+the_short_illative_is_in_the_table()
+every_form_string_is_one_vabamorf_accepts()
 
 if failures:
     print(f"\n{len(failures)} failure(s):")

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -355,7 +355,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },
@@ -569,7 +569,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -737,17 +737,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -764,18 +764,18 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -787,7 +787,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1330,10 +1330,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1383,9 +1383,9 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -1436,7 +1436,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2068,10 +2068,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -2112,10 +2112,10 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -2153,7 +2153,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2214,7 +2214,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2428,8 +2428,8 @@ name = "uvicorn"
 version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }


### PR DESCRIPTION
A reader checked `data/inflection_et_eki_disputes.json` against his own Estonian inflection corpus and wrote to say what he had measured about parallel forms. The prompt to look was his; the three defects are ours.

## `paradigm` never generated the short illative

Estonian has two illatives for many words, the long `majasse` and the short `majja`, and Vabamorf generates the short one under a form code of its own: `adt`, no number prefix, singular only. The nominal table never asked for it.

| word | returned | missing |
| --- | --- | --- |
| maja | majasse | **majja** |
| käsi | käesse | **kätte** |
| meri | meresse | **merre** |
| kivi | kivisse | **kivvi** |

For those words the short form is the one people write, so an agent reading the table would "correct" a correct `majja` into `majasse`, which is the failure this server exists to prevent. The slot is generated where it exists, absent where it does not (`raamat`, `auto` and `töö` have none), and carries its Estonian name.

The note that goes with it says both are correct illatives, and one thing the table cannot say on its own: for most words that have a short illative it is spelled exactly like the singular partitive (`vend`: `venda` is both), so finding a surface here does not confirm the case is right where it was used. Without that sentence, a surface found in the table reads as confirmation that the case is right where it was used, which it is not.

## Two more form codes that generated nothing

`tava` sat in the verb list and synthesises nothing for any verb, so its slot never appeared. `tavat` (`kasutatavat`), the counterpart to the `vat` already there, does exist and takes its place. `ksid` was listed twice, for the conditional 2nd person singular and the 3rd person plural, which share a surface and a label, so the table carried two byte-identical entries; the past tense's identical syncretism (`sid`) was already listed once. Verbs stay at 30 forms.

## The benchmark harness only looked like it scored short illatives

`scripts/eval_inflection.py` listed `adt` beside `ill`, then prefixed the number and asked Vabamorf for `sg adt`, a code it answers nothing to.

**The published numbers do not move**: 99.1% any-candidate, 100% EKI-adjudicated, from two full runs against the pinned dataset revision. 115 of the dataset's 200 singular illative rows carry a short gold form our engine generates, but the gold lists both spellings, so long-only output scored anyway. A benchmark sitting at 99.1% was never going to reveal a tool missing the form Estonians actually use.

## Tests

- Short illative present with the right surface for eight words, absent for the four that have none, labelled in Estonian, long form kept alongside.
- A guard that every form code in both tables, and every code the harness builds, synthesises for at least one probe word. This is what found `tava`, and it fails on the old `sg adt` spelling.
- The harness's form order is asserted. `word_surfaces` takes `form_codes[0]` as the first candidate, so putting the short illative first drops published first-candidate accuracy to 87.9% with every other check still green.
- The partitive homograph the note warns about is asserted to be real, so the warning cannot outlive the fact.

Docs updated: tool docstring, README tool table, skill card, CHANGELOG.

## Not changed, deliberately

The verb label map glosses `tav` as "tegumoeline olevikuline kesksõna" and `tud` as "tegumoeline kesksõna", while the removed `tava` entry carried "umbisikuline olevikuline kesksõna", which is the standard term for what `tav` is. "Tegumoeline" appears nowhere else in the codebase; "umbisikuline tegumood" appears 13 times. That is Estonian grammar terminology and a native speaker's call, so it is untouched and flagged here.

`_synthesize` still turns every exception into `[]`, so a genuine synthesis failure is indistinguishable from "this word has no such form". Pre-existing, and this diff makes absence a documented claim, so it is worth a separate look.

The verb table gained the rarest impersonal form and still lacks commoner ones (`takse`, `ti`, `des`, and the 2nd person singular imperative), all of which synthesise. Out of scope here, worth an issue.
