### PR TITLE
0.5.9: paradigm answered an error to every MCP client, and had since 0.5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,14 @@ jobs:
       - name: Run paradigm tests (inflection_et audit)
         run: uv run --python ${{ matrix.python-version }} python tests/test_paradigm.py
 
+      # Drives every tool through the MCP layer and validates the structured
+      # payload against the schema the tool advertises. `paradigm` answered
+      # isError to every client for two weeks with every other suite green,
+      # because they all call the python functions directly and the failure
+      # lived in between.
+      - name: Run output-schema tests (every tool, through the MCP layer)
+        run: uv run --python ${{ matrix.python-version }} python tests/test_output_schemas.py
+
   # Proves the DOCUMENTED source-install path works, from a clean state.
   # The existing `smoke` job pre-fetches resources through bespoke steps and
   # exports ESTNLTK_MCP_FASTTEXT_PATH, which masks exactly the class of bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.9] — 2026-09-07
+
+### Fixed
+
+- **`paradigm` answered an error to every MCP client, and had since
+  0.5.6.** Not a Python-level failure: `server.paradigm("maja")` returned
+  a correct paradigm the whole time, every suite was green, and the tool
+  still came back as
+  `Output validation error: None is not of type 'string'` over the
+  protocol. The MCP layer builds its structured payload from the tool's
+  output schema and fills every DECLARED BUT ABSENT key with `None`
+  before validating, so each conditional field of `_ParadigmResult`
+  (`paradigm_key`, `other_paradigms`, `ranked_by_corpus_frequency`,
+  `ambiguity_estonian`, `reading_estonian`, `invariant`,
+  `invariant_estonian`, and `word_class*` for words that do not inflect)
+  became a `None` where the schema demanded a string. `total=False` says
+  a key MAY be absent; it does not make the value nullable.
+
+  Those fields are nullable now. `paradigm` is the third most-called tool
+  on the hosted instance, and it was the only tool affected: the others
+  populate every field they declare.
+
+### Added
+
+- **`tests/test_output_schemas.py`: every tool, through the layer that
+  validates.** The gap that let this ship for two weeks is that every
+  existing test calls the Python functions directly, and `mcp.call_tool`
+  does not validate either. This reads each tool's advertised output
+  schema, runs the tool, and checks the structured payload against it,
+  including six `paradigm` word shapes because the omitted-key set
+  differs per word. It fails on the pre-fix code with five violations,
+  and it runs in CI on both Python versions.
+
+
 ## [0.5.8] — 2026-09-07
 
 Both of these came out of a reader checking our

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.8"
+version = "0.5.9"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 _TRUSTED_PROXY_HOPS = max(0, int(os.environ.get("ESTNLTK_MCP_TRUSTED_PROXY_HOPS", "1")))
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.8"
+SERVER_VERSION = "0.5.9"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -1058,21 +1058,28 @@ class _TokenizeResult(TypedDict, total=False):
 
 
 class _ParadigmResult(TypedDict, total=False):
+    # EVERY conditional field is nullable, and that is not cosmetic.
+    # `total=False` says a key may be absent, but the MCP layer builds its
+    # structured payload from this schema and fills each declared-but-
+    # absent key with None before validating. A field typed `str` then
+    # fails validation as "None is not of type 'string'", and the tool
+    # answers isError for every word rather than returning a paradigm.
+    # Only the fields this tool sets on every path stay non-nullable.
     input: str
-    lemma: str
-    partofspeech: str
-    partofspeech_estonian: str
-    word_class: str
-    word_class_estonian: str
+    lemma: str | None
+    partofspeech: str | None
+    partofspeech_estonian: str | None
+    word_class: str | None
+    word_class_estonian: str | None
     forms: list[dict]
     paradigm_count: int
-    paradigm_key: str
-    other_paradigms: list[dict]
-    ranked_by_corpus_frequency: bool
-    ambiguity_estonian: str
-    reading_estonian: str
-    invariant: bool
-    invariant_estonian: str
+    paradigm_key: str | None
+    other_paradigms: list[dict] | None
+    ranked_by_corpus_frequency: bool | None
+    ambiguity_estonian: str | None
+    reading_estonian: str | None
+    invariant: bool | None
+    invariant_estonian: str | None
     summary_estonian: str
     note: str
 

--- a/tests/test_output_schemas.py
+++ b/tests/test_output_schemas.py
@@ -1,0 +1,150 @@
+"""Every tool's real output must satisfy the schema it advertises.
+
+This exists because `paradigm` answered `isError` to every MCP client for
+two weeks and nothing here noticed. The tool functions were fine, the
+tests called them directly, and the failure lived in the layer between:
+the MCP server builds its structured payload from the tool's output
+schema and fills every DECLARED BUT ABSENT key with None before
+validating. A field typed `str` in a `total=False` TypedDict then fails
+as "None is not of type 'string'", and the caller gets an error instead
+of a paradigm.
+
+Calling the python function proves nothing about that, and neither does
+`mcp.call_tool`, which does not validate. So this test does what a client
+does: read the advertised schema, run the tool, and check the structured
+payload against it.
+
+Run via:
+
+    uv run python tests/test_output_schemas.py
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import jsonschema
+
+import server
+
+failures: list[str] = []
+skipped: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  PASS {label}")
+    else:
+        failures.append(f"{label}: {detail}")
+        print(f"  FAIL {label} {detail}")
+
+
+# One representative call per tool, plus the shapes that take a different
+# path through the code. `paradigm` gets six: the bug that prompted this
+# file only appeared for words whose result OMITS an optional key, which
+# is most of them, and the omitted set differs per word.
+CALLS: list[tuple[str, dict]] = [
+    ("tokenize", {"text": "Tere maailm. Teine lause."}),
+    ("lemmatize", {"text": "Koerad jooksevad."}),
+    ("pos_tag", {"text": "Koerad jooksevad."}),
+    ("analyze_morphology", {"text": "Läksin majja."}),
+    ("spell_check", {"text": "Tere maailm"}),
+    ("syllabify", {"word": "koerad"}),
+    ("named_entities", {"text": "Tallinn on Eesti pealinn."}),
+    ("paradigm", {"word": "maja"}),          # single paradigm, most keys absent
+    ("paradigm", {"word": "kott"}),          # two paradigms, key + others present
+    ("paradigm", {"word": "kaunis"}),        # promoted reading
+    ("paradigm", {"word": "kasutama"}),      # verb table
+    ("paradigm", {"word": "ja"}),            # does not inflect
+    ("paradigm", {"word": "qwertyxyz"}),     # not analysable
+    ("classify_register", {"text": "Käesoleva lepingu alusel sätestatakse kohustused."}),
+    ("check_style", {"text": "Süsteem kasutab andmeid. Andmed töödeldakse."}),
+    ("check_officialese", {"text": "Aruandeperioodil koguti ja valideeriti andmestik."}),
+    ("check_term_consistency", {"text": "Andmestik ja teadusandmestik."}),
+    ("check_compounds", {"text": "Kooli maja on suur."}),
+    ("check_punctuation", {"text": "Ma tean et see on hea."}),
+    ("check_capitalization", {"text": "Olen Eestlane."}),
+    ("check_numbers", {"text": "Pi on 3.14."}),
+    ("check_redundancy", {"text": "Samuti ka."}),
+    ("check_object_case", {"text": "Ma ei näen koera."}),
+    ("check_abbreviation_hyphenation", {"text": "MCPst tuleb abi."}),
+    ("check_compound_familiarity", {"text": "See on mõtteliin."}),
+    ("check_hyphenation", {"word": "koerad"}),
+    ("check_legalese", {"text": "Käesolev leping."}),
+    ("check_defined_terms", {"text": 'Müüja (edaspidi «Müüja») müüb kauba.'}),
+    ("common_legal_usage", {"word": "hagi"}),
+    ("synonyms", {"word": "kohv"}),                 # needs WordNet
+    ("find_related_words", {"word": "kohv"}),       # needs fastText
+]
+
+# These need a downloaded resource. Absent, the tool raises on purpose and
+# that is the resource tests' business, not this file's.
+NEEDS_RESOURCES = {"synonyms", "find_related_words"}
+
+
+async def run() -> None:
+    tools = {t.name: t for t in await server.mcp.list_tools()}
+
+    print("every registered tool has an output schema")
+    for name, tool in sorted(tools.items()):
+        check(f"{name} advertises one", tool.outputSchema is not None)
+
+    print("and the structured payload a client receives satisfies it")
+    for name, args in CALLS:
+        tool = tools.get(name)
+        if tool is None:
+            check(f"{name} is registered", False, "not in list_tools()")
+            continue
+        label = f"{name}({next(iter(args.values()))!r})"
+        try:
+            _content, structured = await server.mcp.call_tool(name, args)
+        except Exception as e:
+            if name in NEEDS_RESOURCES:
+                skipped.append(f"{label}: {type(e).__name__}")
+                print(f"  SKIP {label} (needs a downloaded resource)")
+                continue
+            check(label, False, f"raised {type(e).__name__}: {str(e)[:90]}")
+            continue
+        try:
+            jsonschema.validate(structured, tool.outputSchema)
+            print(f"  PASS {label}")
+        except jsonschema.ValidationError as e:
+            path = "/".join(str(p) for p in e.absolute_path) or "(root)"
+            check(label, False, f"schema violation at {path}: {e.message[:90]}")
+
+    print("no tool answers isError for a valid call")
+    # The layer turns a schema violation into an error RESULT rather than an
+    # exception, which is why this was invisible: the server stayed up, the
+    # tests stayed green, and every caller got an error string.
+    for name, args in CALLS:
+        if name in NEEDS_RESOURCES:
+            continue
+        content, _structured = await server.mcp.call_tool(name, args)
+        text = ""
+        if content and getattr(content[0], "text", None):
+            text = content[0].text
+        check(f"{name} returns a result, not an error string",
+              "Output validation error" not in text, text[:100])
+
+    print("every tool in the registry is exercised here")
+    registered = set(tools)
+    covered = {name for name, _ in CALLS}
+    missing = registered - covered
+    check("no tool is left untested", not missing, str(sorted(missing)))
+
+
+asyncio.run(run())
+
+if failures:
+    print(f"\n{len(failures)} failure(s):")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+if skipped:
+    print(f"\n{len(skipped)} call(s) skipped for missing resources:")
+    for s in skipped:
+        print(" -", s)
+print("\nall output-schema tests passed")

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
Found while verifying the 0.5.8 deploy by calling the tool over the protocol rather than reading `/health`.

```
$ curl ... '{"method":"tools/call","params":{"name":"paradigm","arguments":{"word":"maja"}}}'
{"content":[{"type":"text","text":"Output validation error: None is not of type 'string'"}],"isError":true}
```

Every word, every client, since 0.5.6 shipped on 23 August. `paradigm` is the third most-called tool on the hosted instance.

## Why nothing caught it

`server.paradigm("maja")` returns a correct paradigm and always did. Every suite is green because they all call the Python functions directly, and `mcp.call_tool` does not validate either. The failure lives in the layer between: the MCP server builds its structured payload from the tool's advertised output schema and fills every **declared but absent** key with `None` before validating.

`total=False` on a TypedDict says a key may be absent. It does not make the value nullable. So each conditional field of `_ParadigmResult` arrived as `None` where the schema demanded a string:

| word | keys the layer filled with None |
| --- | --- |
| maja | `paradigm_key`, `other_paradigms`, `ranked_by_corpus_frequency`, `ambiguity_estonian`, `reading_estonian`, `invariant`, `invariant_estonian` |
| kott | `reading_estonian`, `invariant`, `invariant_estonian` |
| ja | the above plus `word_class`, `word_class_estonian` |

Those fields are nullable now. `paradigm` was the only tool affected: every other one populates what it declares, which I verified by driving all 26 through the same path.

## The test that should have existed

`tests/test_output_schemas.py` does what a client does. It reads each tool's advertised output schema, runs the tool, validates the structured payload, and separately asserts that no tool returns an `Output validation error` string. `paradigm` gets six word shapes, because the omitted-key set differs per word: single paradigm, two paradigms, promoted reading, verb, non-inflecting, unanalysable.

Reverting one field to `str` makes it fail with five violations, which is how I know it tests the thing. It also asserts every registered tool appears in its own call table, so a new tool cannot quietly skip it. CI runs it on 3.11 and 3.13.

## Note on severity

The server never crashed and never logged an error: a schema violation becomes an error *result*, not an exception, so `/metrics` recorded these as ordinary tool calls. Any monitoring built on status codes or the 5xx ring buffer would have shown nothing wrong for two weeks.