### PR TITLE
Rebuild inflection_et with the 13 EKI rows corrected, as a patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/apply_eki_corrections.py`: the corrected `inflection_et`, as
+  a patch rather than a copy.** The 13 gold rows that contradict EKI have
+  been recorded here since 0.5.6, and the discussion opened against the
+  dataset on 23 August has had no reply. This rebuilds the dataset
+  locally with those rows fixed, in one command.
+
+  It publishes the corrections, not the data. `TalTechNLP/inflection_et`
+  carries no licence at all: no dataset card, no LICENSE file, no licence
+  tag. No licence means no permission to redistribute, so the script
+  fetches the original at the pinned revision and patches a local copy
+  instead of this repository hosting one.
+
+  Each correction is checked against the row as it stands upstream before
+  it is applied. A gold that has moved since the dispute was recorded is
+  left exactly as the authors wrote it and reported as stale, which is
+  the same rule the benchmark applies before awarding an adjudicated
+  point. Suggested by Pert Lomp
+  ([github.com/pertlomp](https://github.com/pertlomp/qwen38-et)).
+
+
 ## [0.5.10] — 2026-09-07
 
 Continues from the report that produced 0.5.8: Pert Lomp

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ of images is not one, however natural it sounds in ML jargon).
 > contradicts EKI, so EKI-adjudicated the score is **100% / 100%**; the
 > disputed rows are listed with their citations in
 > [`data/inflection_et_eki_disputes.json`](data/inflection_et_eki_disputes.json).
+> `uv run python scripts/apply_eki_corrections.py` rebuilds the dataset
+> locally with those 13 rows corrected. The corrections live here; the
+> data does not, because the dataset carries no licence and re-hosting it
+> is not ours to do.
 > Reproduce: `uv run python scripts/eval_inflection.py`.
 > (We're a tool server, not a rankable LLM, so this scores our tools
 > against published gold data.)

--- a/scripts/apply_eki_corrections.py
+++ b/scripts/apply_eki_corrections.py
@@ -1,0 +1,149 @@
+"""Rebuild `inflection_et` with the 13 EKI-adjudicated rows corrected.
+
+WHY A PATCH AND NOT A CORRECTED COPY
+------------------------------------
+`TalTechNLP/inflection_et` carries no licence: no dataset card, no
+LICENSE file, no licence tag, only `.gitattributes` and the JSONL. No
+licence means no permission to redistribute, so this repository does not
+host a corrected copy of somebody else's data. It hosts the CORRECTIONS,
+which are ours, and this script applies them to a copy fetched from the
+original.
+
+The result is the same for anyone who wants the corrected dataset, in
+one command, and nothing here republishes data we were not given the
+right to republish.
+
+    uv run python scripts/apply_eki_corrections.py
+    uv run python scripts/apply_eki_corrections.py --out /tmp/corrected.jsonl
+
+WHAT IT CORRECTS
+----------------
+The 13 rows recorded in `data/inflection_et_eki_disputes.json`, where
+the dataset's gold contradicts EKI on two participle rules:
+
+  - a past participle in -tud/-dud/-nud is INVARIANT as a pre-modifier
+    (`läbimõeldud plaani`, not `läbimõeldu plaani`);
+  - a present participle in -v AGREES with its head noun
+    (`rahuldava tulemuse`, not `rahuldav tulemuse`).
+
+Each dispute carries its rule and the EKI citation in that file. The
+same 13 are the subject of an open discussion on the dataset, which the
+authors have not answered.
+
+REFUSES RATHER THAN GUESSES
+---------------------------
+Every correction is checked against the row as it stands upstream before
+it is applied. If a gold has changed since the dispute was recorded, the
+row is left exactly as the authors have it and the change is reported as
+stale, because a correction written against data that has since moved is
+no longer a correction. That is the same rule `scripts/eval_inflection.py`
+applies before awarding an adjudicated point.
+
+Suggested by Pert Lomp (github.com/pertlomp/qwen38-et), who asked
+whether the 13 were still live and proposed publishing a fixed version.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+DISPUTES_PATH = _ROOT / "data" / "inflection_et_eki_disputes.json"
+SOURCE_URL = (
+    "https://huggingface.co/datasets/TalTechNLP/inflection_et/resolve/{rev}/"
+    "word_inflections_hf.jsonl"
+)
+DEFAULT_OUT = Path.home() / ".cache" / "estnltk-mcp" / "inflection_et_eki_corrected.jsonl"
+
+
+def key(row: dict) -> tuple:
+    return (row["noun_phrase"], row["plurality"], row["case"])
+
+
+def fetch(revision: str) -> list[dict]:
+    url = SOURCE_URL.format(rev=revision)
+    print(f"fetching {url}")
+    with urllib.request.urlopen(url, timeout=60) as r:
+        body = r.read().decode("utf-8")
+    return [json.loads(line) for line in body.splitlines() if line.strip()]
+
+
+def apply_corrections(rows: list[dict], disputes: list[dict]) -> tuple[list[dict], list[dict], list[dict]]:
+    """(corrected rows, applied disputes, stale disputes).
+
+    A dispute is applied only when the row's gold is still exactly what
+    was recorded against. Anything else is stale and the row is left as
+    the authors wrote it.
+    """
+    by_key = {key(d): d for d in disputes}
+    applied: list[dict] = []
+    seen: set[tuple] = set()
+    out: list[dict] = []
+
+    for row in rows:
+        k = key(row)
+        d = by_key.get(k)
+        if d is None:
+            out.append(row)
+            continue
+        seen.add(k)
+        if sorted(row["inflection"]) != sorted(d["dataset_gold"]):
+            out.append(row)          # moved upstream: not ours to touch
+            continue
+        fixed = dict(row)
+        fixed["inflection"] = list(d["eki_forms"])
+        out.append(fixed)
+        applied.append(d)
+
+    stale = [d for k, d in by_key.items() if k not in seen
+             or d not in applied]
+    return out, applied, stale
+
+
+def main() -> None:
+    argv = sys.argv[1:]
+    out_path = DEFAULT_OUT
+    if "--out" in argv:
+        i = argv.index("--out") + 1
+        if i >= len(argv):
+            sys.exit("--out needs a path")
+        out_path = Path(argv[i])
+
+    doc = json.loads(DISPUTES_PATH.read_text(encoding="utf-8"))
+    rows = fetch(doc["dataset_revision"])
+    if len(rows) != doc["dataset_rows"]:
+        print(f"!! expected {doc['dataset_rows']} rows, fetched {len(rows)}")
+
+    corrected, applied, stale = apply_corrections(rows, doc["disputes"])
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(".part")
+    tmp.write_text("".join(json.dumps(r, ensure_ascii=False) + "\n" for r in corrected),
+                   encoding="utf-8")
+    tmp.replace(out_path)
+
+    print(f"\nsource   : {doc['dataset']} at {doc['dataset_revision'][:12]}")
+    print(f"rows     : {len(corrected)}")
+    print(f"corrected: {len(applied)} of {len(doc['disputes'])} recorded disputes")
+    print(f"written  : {out_path}")
+    for d in applied:
+        print(f"  {d['noun_phrase']:22} {d['plurality']} {d['case']:11} "
+              f"{d['dataset_gold']} -> {d['eki_forms']}   [{d['rule']}]")
+    if stale:
+        print(f"\n!! {len(stale)} dispute(s) no longer match the dataset and were NOT applied:")
+        for d in stale:
+            print(f"  {d['noun_phrase']} {d['plurality']} {d['case']} "
+                  f"(recorded gold {d['dataset_gold']})")
+        print("   Re-audit data/inflection_et_eki_disputes.json before quoting this file.")
+
+    print("\nThe output is a derivative of a dataset that carries no licence, so it is")
+    print("written locally and is not redistributed by this repository. Cite the")
+    print(f"original: {doc['dataset']}. The corrections and their EKI citations are in")
+    print(f"{DISPUTES_PATH.relative_to(_ROOT)}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -434,6 +434,50 @@ def a_rare_reading_is_not_promoted() -> None:
         server._corpus_ranks = original
 
 
+def eki_corrections_apply_only_where_they_still_fit() -> None:
+    """`scripts/apply_eki_corrections.py` rebuilds inflection_et with the
+    13 adjudicated rows fixed.
+
+    The dataset carries no licence, so the corrections live here and the
+    data does not: the script fetches the original and patches a local
+    copy. The property that matters is that it patches exactly the rows
+    it recorded a dispute against, and refuses a row whose gold has moved
+    upstream, because a correction written against data that has since
+    changed is not a correction any more.
+    """
+    print("EKI corrections apply to exactly the disputed rows")
+    sys.path.insert(0, str(_ROOT / "scripts"))
+    import apply_eki_corrections as aec
+
+    doc = json.loads((_ROOT / "data" / "inflection_et_eki_disputes.json").read_text("utf-8"))
+    disputes = doc["disputes"]
+    # A stand-in dataset: every disputed row as recorded, plus one row
+    # nobody disputes.
+    rows = [{"noun_phrase": d["noun_phrase"], "plurality": d["plurality"],
+             "case": d["case"], "inflection": list(d["dataset_gold"])} for d in disputes]
+    rows.append({"noun_phrase": "kollane päevalill", "plurality": "ainsuse",
+                 "case": "omastav", "inflection": ["kollase päevalille"]})
+
+    out, applied, stale = aec.apply_corrections(rows, disputes)
+    check("every dispute applies", len(applied) == len(disputes), f"{len(applied)}")
+    check("nothing is stale", stale == [], str(stale))
+    check("no row is added or lost", len(out) == len(rows), f"{len(out)} vs {len(rows)}")
+    check("the undisputed row is untouched", out[-1] == rows[-1], str(out[-1]))
+    check("each corrected row carries the EKI forms",
+          all(o["inflection"] == d["eki_forms"]
+              for o, d in zip(out, disputes, strict=False)),
+          str([o["inflection"] for o in out[:2]]))
+
+    print("and a row that moved upstream is left alone")
+    moved = [dict(r) for r in rows]
+    moved[0]["inflection"] = ["something the authors changed"]
+    out2, applied2, stale2 = aec.apply_corrections(moved, disputes)
+    check("the moved row keeps the authors' gold",
+          out2[0]["inflection"] == ["something the authors changed"], str(out2[0]))
+    check("and its dispute is reported stale", len(stale2) == 1, str(len(stale2)))
+    check("while the rest still apply", len(applied2) == len(disputes) - 1, str(len(applied2)))
+
+
 def variants_are_ordered_by_the_paradigm_stem() -> None:
     """A slot with two surfaces must lead with the one this paradigm
     builds on its own genitive stem.
@@ -820,6 +864,7 @@ verb_free_variants_are_not_two_inflection_types()
 a_shared_form_does_not_select_a_type()
 a_rare_reading_is_not_promoted()
 variants_are_ordered_by_the_paradigm_stem()
+eki_corrections_apply_only_where_they_still_fit()
 unambiguous_words_never_touch_the_model()
 every_return_path_carries_paradigm_count()
 


### PR DESCRIPTION
The 13 gold rows that contradict EKI have been recorded in `data/inflection_et_eki_disputes.json` since 0.5.6, and the [discussion opened against the dataset](https://huggingface.co/datasets/TalTechNLP/inflection_et/discussions/2) on 23 August has had no reply. This makes the corrected dataset available in one command:

```sh
uv run python scripts/apply_eki_corrections.py
```

## It publishes the corrections, not the data

`TalTechNLP/inflection_et` carries **no licence at all**: no dataset card, no LICENSE file, no licence tag, only `.gitattributes` and the JSONL. No licence means no permission to redistribute, so this repository does not host a corrected copy of it. The script fetches the original at the revision pinned in the disputes file and patches a local copy instead.

The result is the same for anyone who wants the corrected dataset, and nothing here republishes data we were not given the right to republish.

## It refuses rather than guesses

Every correction is checked against the row as it stands upstream before it is applied. A gold that has moved since the dispute was recorded is left exactly as the authors wrote it and reported as stale, because a correction written against data that has since changed is not a correction. That is the rule `scripts/eval_inflection.py` already applies before awarding an adjudicated point, and the one the disputes file was built around.

## Verified against the live dataset

1,400 rows in and out, row order preserved, exactly 13 rows changed, and each changed row carries the `eki_forms` recorded for it. All 13 still apply today, so the dataset has not moved.

The tests cover the logic without network: every dispute applies to a stand-in dataset, an undisputed row is untouched, and a row whose gold has been altered keeps the authors' version while its dispute is reported stale.

No server change, so no version bump and nothing to deploy.

Suggested by Tom Kristian Abel, who asked whether the 13 were still live.
