### PR TITLE
0.6.0: the verb table covers what people write, and forms carry their Estonian name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,64 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-09-08
+
+### Fixed
+
+- **The verb table carried the rare forms and omitted the common ones.**
+  `vat` (`kasutavat`) was in it and does not occur in the corpus
+  vocabulary at all; `tavat` (`kasutatavat`) is rank 24,225. `takse`
+  (`kasutatakse`) was absent, and it is rank 232. Estonian officialese is
+  written largely in the umbisikuline tegumood, and the table carried
+  that voice's participles and its quotative but none of its indicative
+  or conditional forms: no `kasutatakse`, no `kasutati`, no
+  `kasutataks`. An agent asking for a verb's paradigm could not find the
+  form the text in front of it was using.
+
+  The table now covers the umbisikuline finite forms (`takse`, `ti`,
+  `taks`, `ta`, `tagu`), the `des`- and `maks`-vorm, the 2nd person
+  singular imperative (`kasuta`) and the synthetic past conditional
+  (`kasutanuks`). 39 forms where there were 30, every one of which
+  Vabamorf generates, which a test enforces.
+
+- **Three labels named one reading of a form that has two.** `kasuta` is
+  the imperative and equally the form after `ei` (`ei kasuta`), and was
+  labelled only "käskiv 2.p ainsus". `kasutagu` is 3rd person of either
+  number (`ta tulgu`, `nad tulgu`) and was labelled singular.
+  `kasutaks` serves every person without an ending (`ma kasutaks`) and
+  was labelled 3rd person singular. Each now names both readings, the
+  way `sid` and `ksid` already did.
+
+- **Participle labels named the voice with a word this codebase uses
+  nowhere else.** `tud` was "tegumoeline kesksõna" and `tav`
+  "tegumoeline olevikuline kesksõna", while "umbisikuline tegumood"
+  appears throughout the rest of the file. The four participles are now
+  labelled symmetrically: `v` isikuline oleviku kesksõna, `nud`
+  isikuline mineviku kesksõna, `tav` umbisikuline oleviku kesksõna,
+  `tud` umbisikuline mineviku kesksõna.
+
 ### Added
 
-- **`scripts/apply_eki_corrections.py`: the corrected `inflection_et`, as
-  a patch rather than a copy.** The 13 gold rows that contradict EKI have
-  been recorded here since 0.5.6, and the discussion opened against the
-  dataset on 23 August has had no reply. This rebuilds the dataset
-  locally with those rows fixed, in one command.
+- **`analyze_morphology` names its form codes in Estonian.** It returned
+  the raw Vabamorf code, so a caller was told a word is `adt` or `takse`
+  and left to guess, in a server whose stated rule is that every English
+  label carries a correct Estonian rendering. Each word now has
+  `form_estonian` beside `form`, drawn from the same label tables
+  `paradigm` uses. A code with no label gives `null` rather than echoing
+  itself, so a caller can tell a name from the absence of one.
 
-  It publishes the corrections, not the data. `TalTechNLP/inflection_et`
-  carries no licence at all: no dataset card, no LICENSE file, no licence
-  tag. No licence means no permission to redistribute, so the script
-  fetches the original at the pinned revision and patches a local copy
-  instead of this repository hosting one.
+  Every form code Vabamorf declares is covered, including the ones no
+  paradigm slot lists: the personal past conditional (`kasutanuksin`),
+  the past quotatives (`kasutanuvat`), the umbisikuline supine
+  (`ehitatama`) and its past conditional (`kasutatuks`).
 
-  Each correction is checked against the row as it stands upstream before
-  it is applied. A gold that has moved since the dispute was recorded is
-  left exactly as the authors wrote it and reported as stale, which is
-  the same rule the benchmark applies before awarding an adjudicated
-  point. Suggested by Pert Lomp
-  ([github.com/pertlomp](https://github.com/pertlomp/qwen38-et)).
-
+  The negatives are read against the word's lemma. Vabamorf gives one
+  code to three unrelated words, so `neg o` is `ära`, and also `pole`,
+  and also `lähe`; the lemma is what separates them. Naming the
+  negatives by prefixing "eitav" to the ordinary label for the suffix
+  would call `pole` a command, `polnud` a past participle, `ärme` an
+  indicative and `lähe` in `ei lähe` a command as well. Each is a whole
+  word an agent meets in ordinary Estonian.
 
 ## [0.5.10] — 2026-09-07
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ of images is not one, however natural it sounds in ML jargon).
 | Tool | What it does |
 | --- | --- |
 | `tokenize(text)` | Split text into sentences and words |
-| `analyze_morphology(text)` | Lemma, POS, form, root, ending, clitic, compound parts, ambiguity count, and usage flags (archaic / foreign / interjection / abbreviation / proper-noun) per word |
-| `paradigm(word)` | Full Vabamorf-generated inflection paradigm, 14 cases × 2 numbers for nominals (including ordinals, comparatives and superlatives), plus the short illative where a word has one (`majja` beside `majasse`), ~31 verb forms, with Estonian labels per form. A lemma with several inflection types (`kott` → `koti` or `kota`, two different words) returns one consistent table per type, corpus-ranked, rather than a merged one; pass an inflected form (`koti`) to select the type you mean |
+| `analyze_morphology(text)` | Lemma, POS, form and its Estonian name, root, ending, clitic, compound parts, ambiguity count, and usage flags (archaic / foreign / interjection / abbreviation / proper-noun) per word |
+| `paradigm(word)` | Full Vabamorf-generated inflection paradigm, 14 cases × 2 numbers for nominals (including ordinals, comparatives and superlatives), plus the short illative where a word has one (`majja` beside `majasse`), ~39 verb forms including the umbisikuline tegumood (`kasutatakse`, `kasutati`), with Estonian labels per form. A lemma with several inflection types (`kott` → `koti` or `kota`, two different words) returns one consistent table per type, corpus-ranked, rather than a merged one; pass an inflected form (`koti`) to select the type you mean |
 | `lemmatize(text)` | Just the dictionary form per word |
 | `pos_tag(text)` | Just the part-of-speech tag per word |
 | `spell_check(text)` | Spelling check + correction suggestions |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "estonian-mcp"
-version = "0.5.10"
+version = "0.6.0"
 description = "Offline MCP server wrapping EstNLTK, EKI Reeglid, and Riigi Teataja so AI agents write better Estonian. 26 tools: spell-check, morphology, paradigm, synonyms, related-words, register, style, redundancy, orthography (capitalisation, compounds, commas, numbers), case-government, calque-risk, kantseliit/officialese and terminology-consistency checks for reports and academic prose, plus legalese simplification and defined-term tracking for legal texts, and canonical legal-usage collocations."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ DEFAULT_PUBLIC_RATE_LIMIT_PER_MINUTE = 300
 _TRUSTED_PROXY_HOPS = max(0, int(os.environ.get("ESTNLTK_MCP_TRUSTED_PROXY_HOPS", "1")))
 
 # Bumped manually in lockstep with pyproject.toml's [project].version.
-SERVER_VERSION = "0.5.10"
+SERVER_VERSION = "0.6.0"
 
 # Favicons served alongside the MCP endpoint so Google's favicon service
 # (used by the Anthropic Connectors Directory + tool-call UI in Claude)
@@ -572,7 +572,7 @@ _CASE_LABELS_ET: dict[str, str] = {
 
 _VERB_FORMS: tuple[str, ...] = (
     # infinitives + supine
-    "ma", "da", "vat", "tavat", "mas", "mast", "mata",
+    "ma", "da", "des", "maks", "vat", "tavat", "mas", "mast", "mata",
     # present indicative (1sg, 2sg, 3sg, 1pl, 2pl, 3pl)
     "n", "d", "b", "me", "te", "vad",
     # past indicative
@@ -584,8 +584,16 @@ _VERB_FORMS: tuple[str, ...] = (
     "ksin", "ksid", "ks", "ksime", "ksite",
     # participles
     "nud", "tud", "v", "tav",
-    # imperative (mostly 2nd / 3rd person)
-    "gu", "gem", "ge",
+    # imperative
+    "o", "gu", "gem", "ge",
+    # umbisikuline tegumood. The table carried its participles (tud,
+    # tav) and its quotative (tavat) but none of its indicative or
+    # conditional forms, though this is the voice official Estonian is
+    # largely written in: kasutatakse is rank 232 in the corpus
+    # vocabulary, well ahead of kasutatavat at 24,225.
+    "takse", "ti", "taks", "ta", "tagu",
+    # synthetic past conditional
+    "nuks",
 )
 
 # Passive-voice form codes from Vabamorf. When analyze_morphology
@@ -663,6 +671,7 @@ _REPETITION_SKIP_POS: frozenset[str] = frozenset({
 
 _VERB_LABELS_ET: dict[str, str] = {
     "ma": "ma-tegevusnimi", "da": "da-tegevusnimi",
+    "des": "des-vorm", "maks": "maks-vorm",
     "vat": "vat-vorm", "tavat": "tavat-vorm", "mas": "mas-vorm",
     "mast": "mast-vorm", "mata": "mata-vorm",
     "n": "olevik 1.p ainsus", "d": "olevik 2.p ainsus",
@@ -672,12 +681,76 @@ _VERB_LABELS_ET: dict[str, str] = {
     "s": "lihtminevik 3.p ainsus", "sime": "lihtminevik 1.p mitmus",
     "site": "lihtminevik 2.p mitmus",
     "ksin": "tingiv 1.p ainsus", "ksid": "tingiv 2.p ainsus / 3.p mitmus",
-    "ks": "tingiv 3.p ainsus", "ksime": "tingiv 1.p mitmus",
+    "ks": "tingiv 3.p ainsus / pöördelõputa vorm",
+    "ksime": "tingiv 1.p mitmus",
     "ksite": "tingiv 2.p mitmus",
-    "nud": "mineviku kesksõna", "tud": "tegumoeline kesksõna",
-    "v": "olevikuline kesksõna", "tav": "tegumoeline olevikuline kesksõna",
-    "gu": "käskiv 3.p ainsus", "gem": "käskiv 1.p mitmus",
-    "ge": "käskiv 2.p mitmus",
+    "nud": "isikuline mineviku kesksõna",
+    "tud": "umbisikuline mineviku kesksõna",
+    "v": "isikuline oleviku kesksõna",
+    "tav": "umbisikuline oleviku kesksõna",
+    # `o` is the imperative AND the form after `ei` (ei tea, ei kasuta),
+    # and `gu` is 3rd person of either number (ta tulgu, nad tulgu).
+    "o": "käskiv 2.p ainsus / isikuline eitav vorm",
+    "gu": "käskiv 3.p ainsus / mitmus",
+    "gem": "käskiv 1.p mitmus", "ge": "käskiv 2.p mitmus",
+    "takse": "umbisikuline olevik", "ti": "umbisikuline lihtminevik",
+    "taks": "umbisikuline tingiv", "ta": "umbisikuline eitav vorm",
+    "tagu": "umbisikuline käskiv",
+    "nuks": "tingiv minevik",
+}
+
+
+# Forms Vabamorf returns that no paradigm slot lists: the personal past
+# conditional's persons, the past quotatives, and the umbisikuline
+# supine and past conditional. Rare, but a caller who meets one deserves
+# its name rather than a bare code.
+_ANALYSIS_FORM_LABELS_ET: dict[str, str] = {
+    "nuksin": "tingiv minevik 1.p ainsus",
+    "nuksid": "tingiv minevik 2.p ainsus / 3.p mitmus",
+    "nuksime": "tingiv minevik 1.p mitmus",
+    "nuksite": "tingiv minevik 2.p mitmus",
+    "nuvat": "nuvat-vorm", "tuvat": "tuvat-vorm",
+    "tuks": "umbisikuline tingiv minevik",
+    "tama": "umbisikuline ma-tegevusnimi",
+}
+
+
+# A `neg` code belongs to one of three words, and the same code means
+# different things in each: `neg o` is `ära`, the imperative negator,
+# but it is also `pole` and `lähe`, neither of which is an imperative.
+# The lemma separates them — every other `neg` code belongs to one word
+# — so the label is looked up by lemma rather than composed by prefixing
+# "eitav" to the suffix's ordinary label, which called `pole` a command,
+# `polnud` a participle and `ärme` an indicative.
+_NEG_LEMMA_FAMILY: dict[str, str] = {
+    "ära": "ära", "olema": "olema", "ole": "olema",
+    "minema": "minema", "mine": "minema",
+}
+_NEG_LABELS_ET: dict[str, dict[str, str]] = {
+    # ära, ärge, ärgem, ärme, ärgu: the negator's own imperative paradigm.
+    "ära": {
+        "o": "eitav käskiv 2.p ainsus",
+        "ge": "eitav käskiv 2.p mitmus",
+        "gem": "eitav käskiv 1.p mitmus",
+        "me": "eitav käskiv 1.p mitmus",
+        # Vabamorf gives `neg gu` no person: `ärgu` covers `ärgu ta
+        # tulgu`, `ärgu nad tulgu` and the umbisikuline `ärgu tehtagu`.
+        "gu": "eitav käskiv",
+    },
+    # pole, polda, polnud, poldud, poleks, polnuks, polevat: olema's
+    # contracted negatives, which carry no person at all.
+    "olema": {
+        "o": "eitav olevik",
+        "da": "umbisikuline eitav vorm",
+        "nud": "eitav lihtminevik",
+        "tud": "umbisikuline eitav lihtminevik",
+        "ks": "eitav tingiv",
+        "nuks": "eitav tingiv minevik",
+        "vat": "eitav vat-vorm",
+    },
+    # lähe: minema's suppletive negative stem, as in `ei lähe`. The same
+    # slot other verbs fill with the plain `o` code (ei tule, ei anna).
+    "minema": {"o": "isikuline eitav vorm"},
 }
 
 
@@ -1414,6 +1487,7 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
                     "lemma": lemmas[i],
                     "partofspeech": pos[i],
                     "form": forms[i],
+                    "form_estonian": _form_et(forms[i], lemmas[i]),
                     "root": roots[i],
                     "ending": endings[i],
                     "clitic": clitics[i],
@@ -1436,6 +1510,7 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
                 "lemma": _first(lemmas),
                 "partofspeech": _first(pos),
                 "form": _first(forms),
+                "form_estonian": _form_et(_first(forms), _first(lemmas)),
                 "root": _first(roots),
                 "ending": _first(endings),
                 "clitic": _first(clitics),
@@ -1447,6 +1522,33 @@ def analyze_morphology(text: Annotated[str, Field(description="Estonian text to 
                 "indeclinable": indeclinable,
             })
     return out
+
+
+def _form_et(code: str, lemma: str | None = None) -> str | None:
+    """The Estonian name of a Vabamorf form code, or None.
+
+    `paradigm` has labelled its forms since it existed, while
+    `analyze_morphology` returned the raw code: a caller was told a word
+    is `adt` or `takse` and left to guess, in a server whose stated rule
+    is that every English label carries a correct Estonian rendering.
+
+    `lemma` only matters for the `neg` codes, where one code covers
+    three unrelated words (see _NEG_LABELS_ET). Without it they go
+    unnamed rather than guessed at.
+
+    None rather than the code itself when there is no label, so a caller
+    can tell "this is the Estonian name" from "we do not have one", and
+    so a missing label cannot masquerade as terminology.
+    """
+    if not code:
+        return None
+    if code == "neg":
+        return "eitussõna"
+    if code.startswith("neg "):
+        family = _NEG_LEMMA_FAMILY.get((lemma or "").lower())
+        return _NEG_LABELS_ET.get(family or "", {}).get(code[4:])
+    return (_CASE_LABELS_ET.get(code) or _VERB_LABELS_ET.get(code)
+            or _ANALYSIS_FORM_LABELS_ET.get(code))
 
 
 # Vabamorf part-of-speech codes whose words inflect as nominals. O, C and
@@ -1908,10 +2010,11 @@ def paradigm(word: Annotated[str, Field(description="A single Estonian word (lem
     words that have one, though, the short illative is spelled exactly
     like the singular partitive (`vend`: `venda` is both), so a surface
     appearing in this table does not confirm the case is right where it
-    was used. For verbs: produces infinitives, present/past/conditional
-    indicative, imperative, and participles (~30 forms). Other parts of
-    speech (adverbs, conjunctions, particles) don't inflect, so `forms`
-    is empty.
+    was used. For verbs: produces infinitives, the indicative present
+    and past, the conditional, the imperative, the participles, and the
+    umbisikuline tegumood's own finite forms (`kasutatakse`, `kasutati`,
+    `kasutataks`), about 39 in all. Other parts of speech (adverbs,
+    conjunctions, particles) don't inflect, so `forms` is empty.
 
     Each form entry has the Vabamorf form code (e.g. `sg p`, `ksin`),
     its Estonian label (e.g. `ainsuse osastav`, `tingiv 1.p ainsus`),

--- a/skills/estonian-writing-assistant/SKILL.md
+++ b/skills/estonian-writing-assistant/SKILL.md
@@ -26,7 +26,7 @@ The hard rule, applied throughout this skill:
 | `spell_check` | First pass on any Estonian text the user wrote. Cheapest validation. |
 | `lemmatize` | Get dictionary forms — for vocabulary study, deduping word stems, citation. |
 | `analyze_morphology` | Full analysis with case form, root, ending, compound parts, ambiguity count, and a usage flag (`archaic` / `foreign` / `interjection` / `abbreviation` / `proper-noun`). The authoritative tool when discussing grammar. |
-| `paradigm` | Generates the full inflection paradigm for a word — all 14 cases for nouns plus the short illative where a word has one (majja beside majasse), ~30 forms for verbs. Use when the user asks "what's the X-case of Y" or wants to see every form. Don't try to recall paradigms from memory. |
+| `paradigm` | Generates the full inflection paradigm for a word — all 14 cases for nouns plus the short illative where a word has one (majja beside majasse), ~39 forms for verbs. Use when the user asks "what's the X-case of Y" or wants to see every form. Don't try to recall paradigms from memory. |
 | `pos_tag` | When you only need POS, e.g., filtering a list to nouns. |
 | `tokenize` | Sentence + word boundaries. Useful before per-sentence operations. |
 | `synonyms` | Same-meaning alternatives via Estonian WordNet. Returns synsets grouped by sense. |

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -308,10 +308,10 @@ def synthesis_invariants() -> None:
           isinstance(server._synthesize("qwertyxyz", "sg g", "S"), list))
 
     print("no form is silently dropped from a table")
-    # 30 for the verb: `tava` synthesised nothing for any verb and was
-    # replaced by `tavat`, which does (kasutatavat), and the duplicated
-    # `ksid` slot is now listed once like the `sid` it mirrors.
-    cases = [("kott", 28), ("maitse", 28), ("esimene", 28), ("kasutama", 30)]
+    # 39 for the verb: 0.6.0 added the umbisikuline finite forms, the
+    # des- and maks-vorm and the 2nd person singular imperative, all of
+    # which Vabamorf generates and none of which the table carried.
+    cases = [("kott", 28), ("maitse", 28), ("esimene", 28), ("kasutama", 39)]
     if HAVE_CORPUS:
         cases.append(("kaunis", 28))   # reaches 28 only once promoted
     for word, n in cases:
@@ -432,6 +432,241 @@ def a_rare_reading_is_not_promoted() -> None:
               f"got {len(r.get('forms', []))} forms")
     finally:
         server._corpus_ranks = original
+
+
+def the_verb_table_covers_what_people_write() -> None:
+    """The table listed `vat`, which does not occur in the corpus
+    vocabulary at all, and `tavat`, which is rank 24,225, and omitted
+    `takse`, which is rank 232.
+
+    Estonian officialese is written largely in the umbisikuline
+    tegumood, and the table carried that voice's participles and its
+    quotative but none of its indicative or conditional forms: no
+    kasutatakse, no kasutati, no kasutataks. An agent asking for a verb's
+    paradigm could not find the form the text in front of it was using.
+    """
+    print("the verb table carries the umbisikuline finite forms")
+    r = server._paradigm("kasutama")
+    got = {e["form"]: (e["surface"], e["form_estonian"]) for e in r["forms"]}
+    for code, surface in (("takse", "kasutatakse"), ("ti", "kasutati"),
+                          ("taks", "kasutataks"), ("ta", "kasutata"),
+                          ("tagu", "kasutatagu")):
+        check(f"{code} -> {surface}", got.get(code, ("",))[0] == surface, str(got.get(code)))
+        check(f"{code} is labelled umbisikuline",
+              "umbisikuline" in (got.get(code, ("", ""))[1] or ""), str(got.get(code)))
+
+    print("and the forms an ordinary writer reaches for")
+    for code, surface in (("des", "kasutades"), ("maks", "kasutamaks"), ("o", "kasuta"),
+                          ("nuks", "kasutanuks")):
+        check(f"{code} -> {surface}", got.get(code, ("",))[0] == surface, str(got.get(code)))
+
+    print("participle labels name the voice, and name it the same way twice")
+    for code in ("v", "nud", "tav", "tud"):
+        check(f"{code}: {_EXPECTED_VERB_LABELS[code]}",
+              got.get(code, ("", ""))[1] == _EXPECTED_VERB_LABELS[code], str(got.get(code)))
+    labels = " ".join(server._VERB_LABELS_ET.values())
+    check("the coined 'tegumoeline' is gone", "tegumoeline" not in labels,
+          "the file uses 'umbisikuline tegumood' everywhere else")
+
+    print("and every slot the paradigm hands back is pinned to its exact name")
+    # Pinned by surface alone, a slot could be relabelled to nonsense and
+    # the whole suite stayed green.
+    for code, expected in _EXPECTED_VERB_LABELS.items():
+        check(f"{code}: {expected}", got.get(code, ("", ""))[1] == expected, str(got.get(code)))
+    check("the table lists exactly the pinned slots",
+          set(server._VERB_LABELS_ET) == set(_EXPECTED_VERB_LABELS),
+          str(set(server._VERB_LABELS_ET) ^ set(_EXPECTED_VERB_LABELS)))
+
+    print("a code covering two slots names both, rather than picking one")
+    # `kasuta` is the imperative AND the form after `ei`; `kasutagu` is
+    # 3rd person of either number; `kasutaks` serves every person without
+    # an ending. Naming only the first reading tells an agent that
+    # "ei tea" is a command and that "nad tulgu" is singular.
+    for code in ("o", "gu", "ks"):
+        check(f"{code} names both readings", " / " in _EXPECTED_VERB_LABELS[code],
+              _EXPECTED_VERB_LABELS[code])
+
+    print("every verb form still synthesises, so nothing was added on faith")
+    for form in server._VERB_FORMS:
+        ok = any(server._synthesize(w, form, "V") for w in ("kasutama", "olema", "tegema"))
+        check(f"{form!r} synthesises", ok, "added to the table but generates nothing")
+
+
+# The 14 cases in each number, plus the short illative, which has no
+# number prefix. `paradigm` labels these and `analyze_morphology` reads
+# the same table, so a wrong one is wrong in both.
+_EXPECTED_CASE_LABELS = {
+    "sg n": "ainsuse nimetav", "sg g": "ainsuse omastav",
+    "sg p": "ainsuse osastav", "sg ill": "ainsuse sisseütlev",
+    "adt": "ainsuse lühike sisseütlev", "sg in": "ainsuse seesütlev",
+    "sg el": "ainsuse seestütlev", "sg all": "ainsuse alaleütlev",
+    "sg ad": "ainsuse alalütlev", "sg abl": "ainsuse alaltütlev",
+    "sg tr": "ainsuse saav", "sg ter": "ainsuse rajav",
+    "sg es": "ainsuse olev", "sg ab": "ainsuse ilmaütlev",
+    "sg kom": "ainsuse kaasaütlev",
+    "pl n": "mitmuse nimetav", "pl g": "mitmuse omastav",
+    "pl p": "mitmuse osastav", "pl ill": "mitmuse sisseütlev",
+    "pl in": "mitmuse seesütlev", "pl el": "mitmuse seestütlev",
+    "pl all": "mitmuse alaleütlev", "pl ad": "mitmuse alalütlev",
+    "pl abl": "mitmuse alaltütlev", "pl tr": "mitmuse saav",
+    "pl ter": "mitmuse rajav", "pl es": "mitmuse olev",
+    "pl ab": "mitmuse ilmaütlev", "pl kom": "mitmuse kaasaütlev",
+}
+
+
+# Every label the two tools can hand back, stated here independently of
+# the tables that produce them, so relabelling one entry fails the suite.
+_EXPECTED_VERB_LABELS = {
+    "ma": "ma-tegevusnimi", "da": "da-tegevusnimi", "des": "des-vorm",
+    "maks": "maks-vorm", "vat": "vat-vorm", "tavat": "tavat-vorm",
+    "mas": "mas-vorm", "mast": "mast-vorm", "mata": "mata-vorm",
+    "n": "olevik 1.p ainsus", "d": "olevik 2.p ainsus", "b": "olevik 3.p ainsus",
+    "me": "olevik 1.p mitmus", "te": "olevik 2.p mitmus", "vad": "olevik 3.p mitmus",
+    "sin": "lihtminevik 1.p ainsus", "sid": "lihtminevik 2.p ainsus / 3.p mitmus",
+    "s": "lihtminevik 3.p ainsus", "sime": "lihtminevik 1.p mitmus",
+    "site": "lihtminevik 2.p mitmus",
+    "ksin": "tingiv 1.p ainsus", "ksid": "tingiv 2.p ainsus / 3.p mitmus",
+    "ks": "tingiv 3.p ainsus / pöördelõputa vorm", "ksime": "tingiv 1.p mitmus",
+    "ksite": "tingiv 2.p mitmus",
+    "nud": "isikuline mineviku kesksõna", "tud": "umbisikuline mineviku kesksõna",
+    "v": "isikuline oleviku kesksõna", "tav": "umbisikuline oleviku kesksõna",
+    "o": "käskiv 2.p ainsus / isikuline eitav vorm",
+    "gu": "käskiv 3.p ainsus / mitmus",
+    "gem": "käskiv 1.p mitmus", "ge": "käskiv 2.p mitmus",
+    "takse": "umbisikuline olevik", "ti": "umbisikuline lihtminevik",
+    "taks": "umbisikuline tingiv", "ta": "umbisikuline eitav vorm",
+    "tagu": "umbisikuline käskiv", "nuks": "tingiv minevik",
+}
+
+# Codes no paradigm slot lists, so only analysis ever returns them.
+_EXPECTED_ANALYSIS_LABELS = {
+    "nuksin": "tingiv minevik 1.p ainsus",
+    "nuksid": "tingiv minevik 2.p ainsus / 3.p mitmus",
+    "nuksime": "tingiv minevik 1.p mitmus",
+    "nuksite": "tingiv minevik 2.p mitmus",
+    "nuvat": "nuvat-vorm", "tuvat": "tuvat-vorm",
+    "tuks": "umbisikuline tingiv minevik",
+    "tama": "umbisikuline ma-tegevusnimi",
+}
+
+# One word each. `neg o` is all three, which is why the lemma decides.
+_EXPECTED_NEG_LABELS = {
+    ("ära", "o"): "eitav käskiv 2.p ainsus",
+    ("ära", "ge"): "eitav käskiv 2.p mitmus",
+    ("ära", "gem"): "eitav käskiv 1.p mitmus",
+    ("ära", "me"): "eitav käskiv 1.p mitmus",
+    ("ära", "gu"): "eitav käskiv",
+    ("olema", "o"): "eitav olevik",
+    ("olema", "da"): "umbisikuline eitav vorm",
+    ("olema", "nud"): "eitav lihtminevik",
+    ("olema", "tud"): "umbisikuline eitav lihtminevik",
+    ("olema", "ks"): "eitav tingiv",
+    ("olema", "nuks"): "eitav tingiv minevik",
+    ("olema", "vat"): "eitav vat-vorm",
+    ("minema", "o"): "isikuline eitav vorm",
+}
+
+
+def analysis_form_codes_carry_their_estonian_name() -> None:
+    """`analyze_morphology` returned raw codes: a caller was told a word
+    is `adt` or `takse` and left to guess, in a server whose rule is that
+    every English label carries a correct Estonian rendering."""
+    print("analyze_morphology glosses its form codes")
+    for text, word, code, label in (
+        ("Läksin majja.", "majja", "adt", "ainsuse lühike sisseütlev"),
+        ("Seda kasutatakse tihti.", "kasutatakse", "takse", "umbisikuline olevik"),
+        ("Ma ei tea.", "ei", "neg", "eitussõna"),
+    ):
+        rec = next(w for w in server.analyze_morphology(text) if w["word"] == word)
+        check(f"{word}: {code} -> {label}",
+              rec["form"] == code and rec["form_estonian"] == label, str(rec.get("form_estonian")))
+
+    print("a neg code is read against its lemma, not by prefixing 'eitav'")
+    # `neg o` is `ära`, and also `pole`, and also `lähe`. Prefixing
+    # "eitav" to the ordinary label for the suffix called `pole` a
+    # command, `polnud` a participle and `ärme` an indicative. Each of
+    # these is a whole word an agent meets in ordinary Estonian, so each
+    # goes through the tool both ways round.
+    for text, word, lemma, code in (
+        ("Ära unusta!", "Ära", "ära", "neg o"),
+        ("Ärge unustage!", "Ärge", "ära", "neg ge"),
+        ("Ärme mine sinna.", "Ärme", "ära", "neg me"),
+        ("Ärgu oldagu pahased.", "Ärgu", "ära", "neg gu"),
+        ("Ma pole kodus.", "pole", "olema", "neg o"),
+        ("Ma polnud kodus.", "polnud", "olema", "neg nud"),
+        ("Ma poleks tulnud.", "poleks", "olema", "neg ks"),
+        ("Seda polda tehtud.", "polda", "olema", "neg da"),
+        ("Seda poldud tehtud.", "poldud", "olema", "neg tud"),
+        ("Ta polevat kodus.", "polevat", "olema", "neg vat"),
+        ("Ma ei lähe koju.", "lähe", "minema", "neg o"),
+    ):
+        expected = _EXPECTED_NEG_LABELS[(lemma, code[4:])]
+        rec = next(w for w in server.analyze_morphology(text) if w["word"] == word)
+        check(f"{word}: {code} ({lemma}) -> {expected}",
+              rec["form"] == code and rec["lemma"] == lemma
+              and rec["form_estonian"] == expected,
+              f"{rec['lemma']!r} {rec['form']!r} -> {rec['form_estonian']!r}")
+        alt = next(a for w in server.analyze_morphology(text, all_analyses=True)
+                   if w["word"] == word for a in w["analyses"] if a["form"] == code)
+        check(f"{word}: same under all_analyses", alt["form_estonian"] == expected,
+              str(alt["form_estonian"]))
+
+    print("the case table is pinned the same way")
+    nominal = {e["form"]: e["form_estonian"] for e in server._paradigm("maja")["forms"]}
+    for code, expected in _EXPECTED_CASE_LABELS.items():
+        check(f"{code}: {expected}", nominal.get(code) == expected, str(nominal.get(code)))
+    check("the case table lists exactly the pinned cases",
+          server._CASE_LABELS_ET == _EXPECTED_CASE_LABELS,
+          str(set(server._CASE_LABELS_ET) ^ set(_EXPECTED_CASE_LABELS)))
+
+    print("and the tables say exactly what they are pinned to say")
+    check("the neg table holds exactly the pinned entries",
+          {(fam, c): lab for fam, d in server._NEG_LABELS_ET.items()
+           for c, lab in d.items()} == _EXPECTED_NEG_LABELS,
+          str(server._NEG_LABELS_ET))
+    check("the analysis-only table holds exactly the pinned entries",
+          server._ANALYSIS_FORM_LABELS_ET == _EXPECTED_ANALYSIS_LABELS,
+          str(server._ANALYSIS_FORM_LABELS_ET))
+
+    print("and a code with no label says so rather than echoing itself")
+    check("unknown codes give None", server._form_et("zzz") is None, str(server._form_et("zzz")))
+    check("an empty code gives None", server._form_et("") is None)
+    # Composition invented "eitav ainsuse nimetav" for this. A lookup cannot.
+    check("a fabricated neg code is not named", server._form_et("neg sg n") is None,
+          str(server._form_et("neg sg n")))
+    check("a neg code without its lemma is not guessed at",
+          server._form_et("neg o") is None, str(server._form_et("neg o")))
+
+    print("every form code Vabamorf declares has a name")
+    # EstNLTK ships Vabamorf's own inventory. Reading it here means a
+    # code we have never seen still fails the test rather than reaching a
+    # caller unnamed.
+    from estnltk.taggers.standard.morph_analysis.morf_common import (
+        VABAMORF_NOUN_FORMS,
+        VABAMORF_VERB_FORMS,
+    )
+    plain = [c for c in VABAMORF_VERB_FORMS if not c.startswith("neg")]
+    unnamed = [c for c in plain if server._form_et(c) is None]
+    check(f"all {len(plain)} plain verb codes are named", not unnamed, str(unnamed))
+    negs = [c for c in VABAMORF_VERB_FORMS if c.startswith("neg ")] + ["neg da"]
+    unnamed = [c for c in negs
+               if not any(server._form_et(c, lm)
+                          for lm in ("ära", "olema", "minema"))]
+    check(f"all {len(negs)} neg codes are named for their lemma", not unnamed, str(unnamed))
+    cases = [c for c in VABAMORF_NOUN_FORMS if c not in ("sg", "pl")]
+    unnamed = [c if c == "adt" else f"{n} {c}"
+               for n in ("sg", "pl") for c in cases
+               if server._form_et(c if c == "adt" else f"{n} {c}") is None]
+    check(f"all {len(cases) * 2 - 1} nominal codes are named", not unnamed, str(unnamed))
+
+    print("coverage over ordinary prose")
+    text = ("Käesoleva lepingu alusel sätestatakse poolte kohustused. Andmeid töödeldakse "
+            "ja säilitatakse seaduses ettenähtud korras. Ma ei tea, kas seda kasutati "
+            "varem. Kasutades neid vahendeid, tuleb olla ettevaatlik. Ära unusta lepingut "
+            "allkirjastada! Seda ei kasutatud ja poleks pidanudki kasutama.")
+    words = [w for w in server.analyze_morphology(text) if w["form"]]
+    missing = [(w["word"], w["form"]) for w in words if w["form_estonian"] is None]
+    check(f"every form code in {len(words)} words is named", not missing, str(missing))
 
 
 def eki_corrections_apply_only_where_they_still_fit() -> None:
@@ -864,6 +1099,8 @@ verb_free_variants_are_not_two_inflection_types()
 a_shared_form_does_not_select_a_type()
 a_rare_reading_is_not_promoted()
 variants_are_ordered_by_the_paradigm_stem()
+the_verb_table_covers_what_people_write()
+analysis_form_codes_carry_their_estonian_name()
 eki_corrections_apply_only_where_they_still_fit()
 unambiguous_words_never_touch_the_model()
 every_return_path_carries_paradigm_count()

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "estonian-mcp"
-version = "0.5.10"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "compress-fasttext" },


### PR DESCRIPTION
## The verb table carried the rare forms and omitted the common ones

`vat` (`kasutavat`) was in it and does not occur in the corpus vocabulary at all. `tavat` (`kasutatavat`) is rank 24,225. `takse` (`kasutatakse`) was not in it, and it is rank 232.

| missing form | example | corpus rank |
| --- | --- | --- |
| `takse` umbisikuline olevik | kasutatakse | 232 |
| `des` des-vorm | kasutades | 805 |
| `ti` umbisikuline lihtminevik | kasutati | 1,000 |
| `o` käskiv 2.p ainsus | kasuta | 3,563 |
| `ta` umbisikuline eitav vorm | kasutata | 8,564 |
| `taks` umbisikuline tingiv | kasutataks | 57,808 |

Estonian officialese is written largely in the umbisikuline tegumood, and the table carried that voice's participles and its quotative but none of its indicative or conditional forms. An agent asking for a verb's paradigm could not find the form the text in front of it was using, which is the failure this server exists to prevent.

39 forms now, where there were 30, adding the umbisikuline finite forms (`takse`, `ti`, `taks`, `ta`, `tagu`), the `des`- and `maks`-vorm, the 2nd person singular imperative and the synthetic past conditional (`kasutanuks`). Every one is generated by Vabamorf, which the existing guard test enforces, so nothing was added on faith.

## Three labels named one reading of a form that has two

| code | before | now |
| --- | --- | --- |
| `o` | käskiv 2.p ainsus | käskiv 2.p ainsus / isikuline eitav vorm |
| `gu` | käskiv 3.p ainsus | käskiv 3.p ainsus / mitmus |
| `ks` | tingiv 3.p ainsus | tingiv 3.p ainsus / pöördelõputa vorm |

`kasuta` is the imperative and equally the form after `ei`, so an agent asking about "ei tea" was told it is a command. `kasutagu` is 3rd person of either number (`nad tulgu`). `kasutaks` serves every person without an ending (`ma kasutaks`). Each names both readings now, the way `sid` and `ksid` already did.

## Participle labels named the voice with a word used nowhere else

`tud` was "tegumoeline kesksõna" and `tav` "tegumoeline olevikuline kesksõna", while "umbisikuline tegumood" appears throughout the rest of the file, including in the comment beside these very codes. The four are symmetric now:

| code | before | now |
| --- | --- | --- |
| `v` | olevikuline kesksõna | isikuline oleviku kesksõna |
| `nud` | mineviku kesksõna | isikuline mineviku kesksõna |
| `tav` | tegumoeline olevikuline kesksõna | umbisikuline oleviku kesksõna |
| `tud` | tegumoeline kesksõna | umbisikuline mineviku kesksõna |

## `analyze_morphology` names its form codes

It returned the raw Vabamorf code, so a caller was told a word is `adt` or `takse` and left to guess, in a server whose stated rule is that every English label carries a correct Estonian rendering. Each word now carries `form_estonian` beside `form`, from the same tables `paradigm` uses. A code with no label gives `null` rather than echoing itself, so a caller can tell a name from the absence of one.

Every form code Vabamorf declares is covered, including the ones no paradigm slot lists: the personal past conditional (`kasutanuksin`), the past quotatives (`kasutanuvat`), the umbisikuline supine (`ehitatama`) and its past conditional (`kasutatuks`). The test reads Vabamorf's own inventory out of EstNLTK, so a code that has never been seen here fails the test rather than reaching a caller unnamed.

### The negatives are read against the lemma

Vabamorf gives one code to three unrelated words: `neg o` is `ära`, and equally `pole`, and equally `lähe`. Naming the negatives by prefixing "eitav" to the ordinary label for the suffix produced this, on words an agent meets in ordinary Estonian:

| word | code | that approach said | correct |
| --- | --- | --- | --- |
| pole | `neg o` | eitav käskiv 2.p ainsus | eitav olevik |
| lähe | `neg o` | eitav käskiv 2.p ainsus | isikuline eitav vorm |
| polnud | `neg nud` | eitav isikuline mineviku kesksõna | eitav lihtminevik |
| poldud | `neg tud` | eitav umbisikuline mineviku kesksõna | umbisikuline eitav lihtminevik |
| polda | `neg da` | eitav da-tegevusnimi | umbisikuline eitav vorm |
| ärme | `neg me` | eitav olevik 1.p mitmus | eitav käskiv 1.p mitmus |
| ärgu | `neg gu` | eitav käskiv 3.p ainsus | eitav käskiv |

It also invented "eitav ainsuse nimetav" for the nonsense code `neg sg n`. The lemma separates the three words cleanly, so the labels are looked up by lemma now, and a code with no entry goes unnamed rather than guessed at. `ärgu` gets no person because Vabamorf assigns it none: it covers `ärgu ta tulgu`, `ärgu nad tulgu` and the umbisikuline `ärgu tehtagu`.

Every label either tool can return is pinned in `tests/test_paradigm.py` independently of the table that produces it, and each table is asserted to hold exactly those entries, so relabelling one to nonsense, or adding an unpinned one, fails the suite.

## Why 0.6.0

This changes what every verb paradigm returns and adds a field to every `analyze_morphology` word. Both are additive, but the paradigm output is materially different, and the version is user-visible at `/health` and in the server card.
