### PR TITLE
Credit the right person for the EKI corrections script

### DIFF
--- a/scripts/apply_eki_corrections.py
+++ b/scripts/apply_eki_corrections.py
@@ -39,8 +39,8 @@ stale, because a correction written against data that has since moved is
 no longer a correction. That is the same rule `scripts/eval_inflection.py`
 applies before awarding an adjudicated point.
 
-Suggested by Pert Lomp (github.com/pertlomp/qwen38-et), who asked
-whether the 13 were still live and proposed publishing a fixed version.
+Suggested by Tom Kristian Abel, who asked whether the 13 were still
+live and proposed publishing a fixed version.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
`scripts/apply_eki_corrections.py` credited Pert Lomp for suggesting it. The suggestion came from Tom Kristian Abel, who asked whether the 13 disputed rows were still live and proposed publishing a fixed version.

Pert Lomp's contribution is the käänamiskorpus benchmark and the parallel-form report behind 0.5.8 and 0.5.10. Those credits in `README.md`, `CHANGELOG.md` and `scripts/eval_kaanamiskorpus.py` are correct and unchanged.

Docstring only. No behaviour change.